### PR TITLE
fix(invoice-adapter-ezpay): fixing meaningless \b in IsExist value by substituting with empty string

### DIFF
--- a/packages/invoice-adapter-ezpay/src/ezpay-invoice-gateway.ts
+++ b/packages/invoice-adapter-ezpay/src/ezpay-invoice-gateway.ts
@@ -351,7 +351,7 @@ export class EZPayInvoiceGateway implements InvoiceGateway<EZPayInvoice, EZPayIn
 
         return {
           ...vars,
-          [key]: decodeURIComponent(value.trim()).replaceAll('\x1B/', ''),
+          [key]: decodeURIComponent(value.trim()).replaceAll('\x1B/', '').replaceAll('\b', ''),
         };
       }, {}) as EZPayInvoiceLoveCodeValidationSuccessResponse;
 


### PR DESCRIPTION
## Issue

ezpay 的 isLoveCodeValid 裡的 payload.IsExist 應該只有 `Y,N`
目前卻出現了 `Y\b\b\b\b\b\b\b\b`

```javascript
console.log({ value: value });
console.log({ value: decodeURIComponent(value!.trim()).replaceAll('\x1B/', '') });
console.log({ value: decodeURIComponent(value!.trim()).replaceAll('\x1B/', '').replaceAll('\b', '') });
console.log('-------');

{ value: 'Y\b\b\b\b\b\b\b\b' }
{ value: 'Y\b\b\b\b\b\b\b\b' }
{ value: 'Y' }
-------
```
目前使用 `.replaceAll('\b', '')` 把多餘的`\b`取代掉，結果是可行的。