### PR TITLE
fix(payments-adapter-ecpay): correct card number existed

### DIFF
--- a/packages/payments-adapter-ecpay/README.md
+++ b/packages/payments-adapter-ecpay/README.md
@@ -108,3 +108,24 @@ function onOrderCommit(order: ECPayOrder<ECPayChannelCreditCard>) {
 
 }
 ```
+
+
+### Handle Card Already Bound
+
+```typescript
+const payment = new ECPayPayment();
+
+payment.emitter.on(
+  PaymentEvents.CARD_BINDING_FAILED,
+  (request: ECPayBindCardRequest) => {
+    // Card already bound
+    if (request.failedMessage?.code === '10100112') {
+      console.log(`memberId: ${request.memberId}`);
+      console.log(`cardId: ${request.cardId}`);
+      console.log(`cardNumberPrefix: ${request.cardNumberPrefix}`);
+      console.log(`cardNumberSuffix: ${request.cardNumberSuffix}`);
+    }
+
+  }
+);
+```

--- a/packages/payments-adapter-ecpay/src/ecpay-bind-card-request.ts
+++ b/packages/payments-adapter-ecpay/src/ecpay-bind-card-request.ts
@@ -133,9 +133,16 @@ export class ECPayBindCardRequest {
     this._gateway.emitter.emit(PaymentEvents.CARD_BOUND, this);
   }
 
-  fail(returnCode: string, message: string) {
+  fail(returnCode: string, message: string, additionalPayload?: ECPayBindCardCallbackPayload) {
     this._failedCode = returnCode;
     this._failedMessage = message;
+
+    if (additionalPayload) {
+      this._cardId = additionalPayload.CardID;
+      this._cardNumberPrefix = additionalPayload.Card6No;
+      this._cardNumberSuffix = additionalPayload.Card4No;
+      this._bindingDate = DateTime.fromFormat(additionalPayload.BindingDate, 'yyyy/MM/dd HH:mm:ss').toJSDate();
+    }
 
     this._gateway.emitter.emit(PaymentEvents.CARD_BINDING_FAILED, this);
   }

--- a/packages/payments-adapter-ecpay/src/ecpay-payment.ts
+++ b/packages/payments-adapter-ecpay/src/ecpay-payment.ts
@@ -324,6 +324,13 @@ export class ECPayPayment<CM extends ECPayCommitMessage = ECPayCommitMessage> im
   }
 
   public handleBindCardResult(request: ECPayBindCardRequest, payload: ECPayBindCardCallbackPayload) {
+    // CardNo is existed.
+    if (payload.RtnCode === 10100112) {
+      request.fail(payload.RtnCode.toString(), payload.RtnMsg, payload);
+
+      return;
+    }
+
     if (payload.RtnCode !== 1) {
       request.fail(payload.RtnCode.toString(), payload.RtnMsg);
 


### PR DESCRIPTION
當綠界 RtnCode 回傳 10100112 表示已經有重複綁卡的情況，這時候可以直接解析 payload 裡的內容，取得信用綁定信用卡的 cardId cardNumberPrefix cardNumberSuffix。