### PR TITLE
feat(invoice-adapter-ecpay): correct gui validator

### DIFF
--- a/packages/invoice-adapter-ecpay/src/ecpay-invoice-gateway.ts
+++ b/packages/invoice-adapter-ecpay/src/ecpay-invoice-gateway.ts
@@ -120,7 +120,7 @@ export class ECPayInvoiceGateway
     const payload = this.decrypt(data.Data) as ECPayInvoiceGUIValidateResponse;
 
     if (payload.RtnCode !== ECPAY_INVOICE_SUCCESS_CODE) {
-      throw new Error('Invalid Response on GUI Validator');
+      return [false];
     }
 
     return [true, payload.CompanyName];

--- a/packages/invoice-adapter-ecpay/src/ecpay-invoice-gateway.ts
+++ b/packages/invoice-adapter-ecpay/src/ecpay-invoice-gateway.ts
@@ -158,6 +158,10 @@ export class ECPayInvoiceGateway
   }
 
   async isMobileBarcodeValid(barcode: string): Promise<boolean> {
+    if (!/^\/[0-9A-Z+\-.]{7}$/.test(barcode)) {
+      return false;
+    }
+
     const { data } = await axios.post<ECPayInvoiceResponse>(
       `${this.baseUrl}/B2CInvoice/CheckBarcode`,
       JSON.stringify({


### PR DESCRIPTION
When `payload.RtnCode` is not equal to `ECPAY_INVOICE_SUCCESS_CODE`, it indicates a validation failure.

See also:
 - https://developers.ecpay.com.tw/?p=22040