### PR TITLE
fix(payments-adapter-ecpay): correct form html unexpected type error

### DIFF
--- a/packages/payments-adapter-ecpay/src/ecpay-order.ts
+++ b/packages/payments-adapter-ecpay/src/ecpay-order.ts
@@ -140,6 +140,10 @@ export class ECPayOrder<OCM extends ECPayCommitMessage> implements Order<OCM> {
 
     this._state = OrderState.PRE_COMMIT;
 
+    if (typeof this.form !== 'object') {
+      return '';
+    }
+
     return `<!DOCTYPE html>
 <html>
   <head>


### PR DESCRIPTION
After querying to retrieve the ECPay order and using formHtml() in the production stage, `this.form` will be undefined.