### PR TITLE
feat: support productType in getCardBalance

### DIFF
--- a/packages/payments-adapter-happy-card/__test__/happy-card-payment.spec.ts
+++ b/packages/payments-adapter-happy-card/__test__/happy-card-payment.spec.ts
@@ -1,0 +1,161 @@
+import { HappyCardPayment } from '../src/happy-card-payment';
+import { HappyCardOrder } from '../src/happy-card-order';
+import {
+  HappyCardProductType,
+  HappyCardRecordType,
+  HappyCardResultCode,
+} from '../src/typings';
+import axios from 'axios';
+
+jest.mock('../src/happy-card-order');
+
+describe('HappyCardPayment.prepare', () => {
+  let gateway: HappyCardPayment;
+
+  beforeEach(() => {
+    gateway = new HappyCardPayment({
+      cSource: 'test-source',
+      key: 'test-key',
+    });
+
+    jest.spyOn(gateway as any, 'getOrderId').mockReturnValue('fixed-order-id');
+
+    // Mock getCardBalance
+    jest.spyOn(gateway, 'getCardBalance').mockResolvedValue([
+      [
+        { id: 1, type: HappyCardRecordType.AMOUNT, amount: 100 },
+        { id: 2, type: HappyCardRecordType.AMOUNT, amount: 50 },
+      ],
+      HappyCardProductType.INVOICE_FIRST_DIGITAL_GIFT_GF,
+    ]);
+  });
+
+  it('should return a HappyCardOrder with correct productType', async () => {
+    const options = {
+      cardSerial: '1234567890',
+      posTradeNo: '1234',
+      items: [
+        { name: 'Item 1', quantity: 1, unitPrice: 100 },
+        { name: 'Item 2', quantity: 1, unitPrice: 50 },
+      ],
+      useRecords: [
+        { id: 1, type: HappyCardRecordType.AMOUNT, amount: 100 },
+        { id: 2, type: HappyCardRecordType.AMOUNT, amount: 50 },
+      ],
+    };
+
+    const result = await gateway.prepare(options);
+
+    expect(gateway.getCardBalance).toHaveBeenCalledWith('1234567890', true);
+    expect(HappyCardOrder).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'fixed-order-id',
+        productType: HappyCardProductType.INVOICE_FIRST_DIGITAL_GIFT_GF,
+        posTradeNo: '1234',
+        items: options.items,
+      }),
+    );
+  });
+});
+
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+describe('HappyCardPayment.getCardBalance (returnRecords = false)', () => {
+  let gateway: HappyCardPayment;
+
+  beforeEach(() => {
+    gateway = new HappyCardPayment({
+      cSource: 'test-source',
+      key: 'test-key',
+    });
+
+    // mock getBaseData so we don't test DateTime or hashing
+    jest.spyOn(gateway, 'getBaseData').mockReturnValue({
+      check: 'MOCKED_CHECKSUM',
+      source: 'test-source',
+      version: '001',
+      store_id: '999999',
+      pos_id: '01',
+      createdate: '2025-06-09T00:00:00.000Z',
+      area: 1,
+    });
+  });
+
+  it('should return record list and productType when returnRecords is true', async () => {
+    mockedAxios.post.mockResolvedValueOnce({
+      data: {
+        resultCode: HappyCardResultCode.SUCCESS,
+        data: {
+          card_list: [
+            {
+              card_sn: '123456',
+              productType: HappyCardProductType.INVOICE_FIRST_DIGITAL_GIFT_GF,
+              amt: 100,
+              record_list: [
+                { record_id: 'r1', type: 1, amt: 60 },
+                { record_id: 'r2', type: 1, amt: 40 },
+              ],
+            },
+            {
+              card_sn: '789',
+              productType: '9',
+              amt: 200,
+              record_list: [{ record_id: 'r3', type: 1, amt: 100 }],
+            },
+          ],
+        },
+      },
+    });
+
+    const result = await gateway.getCardBalance('123456', true);
+
+    expect(mockedAxios.post).toHaveBeenCalled();
+
+    expect(result).toEqual([
+      [
+        { id: 'r1', type: 1, amount: 60 },
+        { id: 'r2', type: 1, amount: 40 },
+      ],
+      HappyCardProductType.INVOICE_FIRST_DIGITAL_GIFT_GF,
+    ]);
+  });
+
+  it('should return total balance and productType when returnRecords is false', async () => {
+    mockedAxios.post.mockResolvedValueOnce({
+      data: {
+        resultCode: HappyCardResultCode.SUCCESS,
+        data: {
+          card_list: [
+            {
+              card_sn: '123456',
+              productType: HappyCardProductType.INVOICE_FIRST_DIGITAL_GIFT_GF,
+              amt: 100,
+              record_list: [],
+            },
+            {
+              card_sn: '7891011',
+              productType: '9',
+              amt: 999,
+              record_list: [],
+            },
+            {
+              card_sn: '234567',
+              productType: HappyCardProductType.INVOICE_FIRST_DIGITAL_GIFT_GF,
+              amt: 50,
+              record_list: [],
+            },
+          ],
+        },
+      },
+    });
+
+    const result = await gateway.getCardBalance('123456', false);
+
+    expect(mockedAxios.post).toHaveBeenCalled();
+    expect(result).toEqual([
+      150,
+      HappyCardProductType.INVOICE_FIRST_DIGITAL_GIFT_GF,
+    ]);
+  });
+});

--- a/packages/payments-adapter-happy-card/src/happy-card-order.ts
+++ b/packages/payments-adapter-happy-card/src/happy-card-order.ts
@@ -4,7 +4,11 @@ import {
   OrderState,
   PaymentEvents,
 } from '@rytass/payments';
-import { HappyCardCommitMessage, HappyCardOrderInitOptions } from './typings';
+import {
+  HappyCardCommitMessage,
+  HappyCardOrderInitOptions,
+  HappyCardProductType,
+} from './typings';
 import { HappyCardOrderItem } from './happy-card-order-item';
 import { HappyCardPayment } from './happy-card-payment';
 import { HappyCardPayRequest } from './typings';
@@ -13,6 +17,7 @@ export class HappyCardOrder<OCM extends HappyCardCommitMessage>
   implements Order<OCM>
 {
   private readonly _id: string;
+  private readonly _productType: HappyCardProductType;
   private readonly _items: HappyCardOrderItem[];
   private readonly _gateway: HappyCardPayment<OCM>;
   private readonly _createdAt: Date;
@@ -27,6 +32,7 @@ export class HappyCardOrder<OCM extends HappyCardCommitMessage>
 
   constructor(options: HappyCardOrderInitOptions) {
     this._id = options.id;
+    this._productType = options.productType;
     this._items = options.items;
     this._gateway = options.gateway;
     this._createdAt = options.createdAt;
@@ -38,6 +44,10 @@ export class HappyCardOrder<OCM extends HappyCardCommitMessage>
 
   get id(): string {
     return this._id;
+  }
+
+  get productType(): string {
+    return this._productType;
   }
 
   get posTradeNo(): string {

--- a/packages/payments-adapter-happy-card/src/typings.ts
+++ b/packages/payments-adapter-happy-card/src/typings.ts
@@ -15,6 +15,7 @@ export interface HappyCardOrderInitOptions<
   OCM extends HappyCardCommitMessage = HappyCardCommitMessage,
 > {
   id: string;
+  productType: HappyCardProductType;
   items: HappyCardOrderItem[];
   gateway: HappyCardPayment<OCM>;
   createdAt: Date;
@@ -106,7 +107,7 @@ export interface HappyCardSearchCardResponse {
       orderSn: string;
       card_sn: string;
       memberGid: string;
-      productType: '1' | '2' | '3' | '4' | '5' | '6';
+      productType: HappyCardProductType;
       productTypeName: string;
       original_amt: number;
       original_bonus: number;
@@ -194,4 +195,13 @@ export interface HappyCardRefundOptions {
 export interface HappyCardCommitOptions {
   payload: Omit<HappyCardPayRequest, 'basedata'>;
   isIsland?: boolean;
+}
+
+export enum HappyCardProductType {
+  INVOICE_FIRST_HAPPY_CARD_GF = '1',
+  INVOICE_LATER_HAPPY_CARD_GS = '2',
+  INVOICE_FIRST_DIGITAL_GIFT_GF = '3',
+  INVOICE_LATER_DIGITAL_GIFT_GS = '4',
+  INVOICE_FIRST_PHYSICAL_GIFT_GF = '5',
+  INVOICE_LATER_PHYSICAL_GIFT_GS = '6',
 }


### PR DESCRIPTION
- Updated ```getCardBalance()``` return type
Now returns a tuple ```[number, HappyCardProductType] | [HappyCardRecord[], HappyCardProductType]```

- Created ```HappyCardProductType``` enum
- Updated ```prepare()``` method
Now extracts ```productType``` from ```getCardBalance()``` result
Passes it to ```HappyCardOrder``` constructor

- Tested updated ```prepare()``` and ```getCardBalance()```