### PR TITLE
Validate VAT numbers in invoice adapters

### DIFF
--- a/packages/invoice-adapter-bank-pro/src/bank-pro-invoice-gateway.ts
+++ b/packages/invoice-adapter-bank-pro/src/bank-pro-invoice-gateway.ts
@@ -5,6 +5,7 @@ import {
   InvoiceGateway,
   InvoiceState,
   TaxType,
+  verifyVatNumber,
 } from '@rytass/invoice';
 import axios from 'axios';
 import { DateTime } from 'luxon';
@@ -47,8 +48,8 @@ export class BankProInvoiceGateway
     this.sellerBAN = options.sellerBAN;
     this.baseUrl = options?.baseUrl || this.baseUrl;
 
-    if (!/^\d{8}$/.test(options.sellerBAN)) {
-      throw new Error('Seller BAN should be 8 digits');
+    if (!verifyVatNumber(options.sellerBAN)) {
+      throw new Error('Seller BAN should not be a valid VAT number');
     }
   }
 
@@ -57,8 +58,8 @@ export class BankProInvoiceGateway
       throw new Error('Order ID is too long, max: 40');
     }
 
-    if (options.vatNumber && !/^\d{8}$/.test(options.vatNumber)) {
-      throw new Error('VAT number should be 8 digits');
+    if (options.vatNumber && !verifyVatNumber(options.vatNumber)) {
+      throw new Error('VAT number is invalid');
     }
 
     if (options.remark && options.remark.length > 100) {

--- a/packages/invoice-adapter-ecpay/src/ecpay-invoice-gateway.ts
+++ b/packages/invoice-adapter-ecpay/src/ecpay-invoice-gateway.ts
@@ -7,6 +7,7 @@ import {
   InvoiceMobileCarrier,
   InvoiceMoicaCarrier,
   TaxType,
+  verifyVatNumber,
 } from '@rytass/invoice';
 import axios from 'axios';
 import isEmail from 'validator/lib/isEmail';
@@ -93,7 +94,7 @@ export class ECPayInvoiceGateway
   }
 
   async isValidGUI(gui: string): Promise<[false] | [true, string]> {
-    if (!/^\d{8}$/.test(gui)) {
+    if (!verifyVatNumber(gui)) {
       return [false];
     }
 
@@ -214,7 +215,7 @@ export class ECPayInvoiceGateway
       throw new Error('`orderId` is required and length less than 30');
     }
 
-    if (options.vatNumber && !/^\d{8}$/.test(options.vatNumber)) {
+    if (options.vatNumber && !verifyVatNumber(options.vatNumber)) {
       throw new Error('Invalid VAT number format');
     }
 

--- a/packages/invoice-adapter-ezpay/src/ezpay-invoice-gateway.ts
+++ b/packages/invoice-adapter-ezpay/src/ezpay-invoice-gateway.ts
@@ -11,6 +11,7 @@ import {
   InvoiceVoidOptions,
   PaymentItem,
   TaxType,
+  verifyVatNumber,
 } from '@rytass/invoice';
 import { createCipheriv, createHash, createDecipheriv } from 'crypto';
 import axios from 'axios';
@@ -165,7 +166,7 @@ export class EZPayInvoiceGateway
       throw new Error('`orderId` is required and length less than 20');
     }
 
-    if (options.vatNumber && !/^\d{8}$/.test(options.vatNumber)) {
+    if (options.vatNumber && !verifyVatNumber(options.vatNumber)) {
       throw new Error('Invalid VAT number format');
     }
 


### PR DESCRIPTION
feat(invoice-adapter-bank-pro): validate VAT numbers using verifyVatNumber utility
feat(invoice-adapter-ezpay): validate VAT numbers using verifyVatNumber utility
feat(invoice-adapter-ecpay): validate VAT numbers using verifyVatNumber utility

Implement VAT number validation using the `verifyVatNumber` utility across multiple invoice adapters to ensure correct formatting and validity.