### PR TITLE
Add createdBy field to BaseArticleVersionEntity

### DIFF
--- a/packages/cms-base-nestjs-module/src/models/base-article-version.entity.ts
+++ b/packages/cms-base-nestjs-module/src/models/base-article-version.entity.ts
@@ -47,6 +47,9 @@ export class BaseArticleVersionEntity {
   @CreateDateColumn()
   createdAt: Date;
 
+  @Column('uuid', { nullable: true })
+  createdBy: string | null;
+
   @DeleteDateColumn()
   deletedAt: Date | null;
 

--- a/packages/cms-base-nestjs-module/src/services/article-base.service.ts
+++ b/packages/cms-base-nestjs-module/src/services/article-base.service.ts
@@ -1301,6 +1301,7 @@ export class ArticleBaseService<
             : undefined,
         releasedAt: this.draftMode ? options.releasedAt : new Date(),
         releasedBy: options.releasedAt ? options.userId : undefined,
+        createdBy: options.userId,
       });
 
       await runner.manager.save(version);
@@ -1448,6 +1449,7 @@ export class ArticleBaseService<
             : undefined,
         releasedAt: this.draftMode ? options.releasedAt : new Date(),
         releasedBy: options.releasedAt ? options.userId : undefined,
+        createdBy: options.userId,
       });
 
       await runner.manager.save(version);


### PR DESCRIPTION
Introduce a createdBy field in the BaseArticleVersionEntity to track the user who created the article version. Update the service to set this field during the creation process.