### PR TITLE
調整文章狀態機邏輯，支援 releaseAt 更新與 withdraw from scheduled

### DIFF
--- a/packages/cms-base-nestjs-graphql-module/src/mutations/article.mutations.ts
+++ b/packages/cms-base-nestjs-graphql-module/src/mutations/article.mutations.ts
@@ -166,7 +166,8 @@ export class ArticleMutations {
   @IsPublic()
   withdrawArticle(
     @Args('id', { type: () => ID }) id: string,
+    @Args('version', { type: () => Int }) version: number,
   ): Promise<BackstageArticleDto> {
-    return this.articleService.withdraw(id);
+    return this.articleService.withdraw(id, version);
   }
 }

--- a/packages/cms-base-nestjs-module/src/services/article-base.service.ts
+++ b/packages/cms-base-nestjs-module/src/services/article-base.service.ts
@@ -864,13 +864,9 @@ export class ArticleBaseService<
       throw new Error('Draft mode is disabled.');
     }
 
-    const article =
-      (await this.findById<A, AV, AVC>(id, {
-        stage: ArticleStage.RELEASED,
-      }).catch((ex) => null)) ??
-      (await this.findById<A, AV, AVC>(id, {
-        stage: ArticleStage.SCHEDULED,
-      }));
+    const article = await this.findById<A, AV, AVC>(id, {
+      stage: ArticleStage.RELEASED,
+    });
 
     const targetPlaceArticle = await this.findById<A, AV, AVC>(id, {
       stage: this.signatureService.signatureEnabled

--- a/packages/cms-base-nestjs-module/src/services/article-base.service.ts
+++ b/packages/cms-base-nestjs-module/src/services/article-base.service.ts
@@ -1865,6 +1865,19 @@ export class ArticleBaseService<
               : null,
         });
 
+        if (this.draftMode && result === ArticleSignatureResult.REJECTED) {
+          await runner.manager.update(
+            this.baseArticleVersionRepo.target,
+            {
+              articleId: articleVersion.id,
+              version: articleVersion.version,
+            },
+            {
+              submittedAt: null,
+            },
+          );
+        }
+
         if (
           this.draftMode &&
           this.autoReleaseAfterApproved &&
@@ -1874,7 +1887,7 @@ export class ArticleBaseService<
           await runner.manager.update(
             this.baseArticleVersionRepo.target,
             {
-              id: articleVersion.id,
+              articleId: articleVersion.id,
               version: articleVersion.version,
               releasedAt: IsNull(),
             },
@@ -1919,11 +1932,24 @@ export class ArticleBaseService<
             : null,
       });
 
+      if (this.draftMode && result === ArticleSignatureResult.REJECTED) {
+        await runner.manager.update(
+          this.baseArticleVersionRepo.target,
+          {
+            articleId: articleVersion.id,
+            version: articleVersion.version,
+          },
+          {
+            submittedAt: null,
+          },
+        );
+      }
+
       if (this.draftMode && this.autoReleaseAfterApproved) {
         await runner.manager.update(
           this.baseArticleVersionRepo.target,
           {
-            id: articleVersion.id,
+            articleId: articleVersion.id,
             version: articleVersion.version,
             releasedAt: IsNull(),
           },

--- a/packages/cms-base-nestjs-module/src/services/article-base.service.ts
+++ b/packages/cms-base-nestjs-module/src/services/article-base.service.ts
@@ -864,9 +864,13 @@ export class ArticleBaseService<
       throw new Error('Draft mode is disabled.');
     }
 
-    const article = await this.findById<A, AV, AVC>(id, {
-      stage: ArticleStage.RELEASED,
-    });
+    const article =
+      (await this.findById<A, AV, AVC>(id, {
+        stage: ArticleStage.RELEASED,
+      }).catch((ex) => null)) ??
+      (await this.findById<A, AV, AVC>(id, {
+        stage: ArticleStage.SCHEDULED,
+      }));
 
     const targetPlaceArticle = await this.findById<A, AV, AVC>(id, {
       stage: this.signatureService.signatureEnabled

--- a/packages/cms-base-nestjs-module/src/services/article-base.service.ts
+++ b/packages/cms-base-nestjs-module/src/services/article-base.service.ts
@@ -958,14 +958,6 @@ export class ArticleBaseService<
           : ArticleStage.SCHEDULED,
     }).catch((ex) => null);
 
-    if (article.releasedAt) {
-      this.logger.debug(
-        `Article ${id} is already released [${article.version}] at ${article.releasedAt}.`,
-      );
-
-      return article;
-    }
-
     this.logger.debug(`Release article ${id} [${article.version}]`);
 
     const willReleasedAt = options?.releasedAt ?? new Date();

--- a/packages/cms-base-nestjs-module/src/services/article-base.service.ts
+++ b/packages/cms-base-nestjs-module/src/services/article-base.service.ts
@@ -972,7 +972,10 @@ export class ArticleBaseService<
     await runner.startTransaction();
 
     try {
-      if (shouldDeleteVersion) {
+      if (
+        shouldDeleteVersion &&
+        shouldDeleteVersion.version !== article.version
+      ) {
         this.logger.debug(
           `Article ${id} is already scheduled or released [${shouldDeleteVersion.version}]. Removing previous version.`,
         );


### PR DESCRIPTION
reject 文章後沒回草稿區 （[待審核] > 選擇不通過（reject）：不會退回 [草稿區]）
withdraw 在 schedule 的時候會噴錯 （[已預約] 也要可以 withdraw，退回 [可發佈]）
似乎要區分單純 release 跟 修改發佈設定的 release (Release 要可以 update+release)
release 或 schedule 要修改 releaseAt 的時間 要可以直接使用releaseArticle 