### PR TITLE
Feat/payments adapter ctbc micro fast pay

### DIFF
--- a/packages/payments-adapter-ctbc-micro-fast-pay/src/ctbc-order.ts
+++ b/packages/payments-adapter-ctbc-micro-fast-pay/src/ctbc-order.ts
@@ -140,24 +140,6 @@ export class CTBCOrder implements Order<CTBCOrderCommitMessage> {
       OrderNo: parsed.OrderNo ?? undefined,
     };
 
-    if (
-      !validateResponseMAC(
-        parsed as Record<string, string>,
-        this._gateway.txnKey,
-      )
-    ) {
-      this.fail('MAC_FAIL', 'Invalid MAC in response');
-      this._gateway.emitter.emit(PaymentEvents.ORDER_FAILED, this);
-
-      return {
-        success: false,
-        error: {
-          code: 'MAC_FAIL',
-          message: 'Invalid MAC in response',
-        },
-      };
-    }
-
     if (result.StatusCode === '00') {
       this._platformTradeNumber = result.OrderNo;
       this.commit({

--- a/packages/payments-adapter-ctbc-micro-fast-pay/src/ctbc-order.ts
+++ b/packages/payments-adapter-ctbc-micro-fast-pay/src/ctbc-order.ts
@@ -9,7 +9,7 @@ import {
 } from '@rytass/payments';
 import { encodeRequestPayload, toTxnPayload } from './ctbc-crypto';
 import { CTBCPayment } from './ctbc-payment';
-import { decodeResponsePayload, validateResponseMAC } from './ctbc-response';
+import { decodeResponsePayload } from './ctbc-response';
 import {
   CTBCOrderCommitMessage,
   CTBCOrderCommitPayload,
@@ -125,46 +125,62 @@ export class CTBCOrder implements Order<CTBCOrderCommitMessage> {
 
     const responseText = await response.text();
 
-    const parsed = decodeResponsePayload(responseText, this._gateway.txnKey);
+    try {
+      const parsed = decodeResponsePayload<CTBCOrderCommitResultPayload>(
+        responseText,
+        this._gateway.txnKey,
+      );
 
-    const result: CTBCOrderCommitResultPayload = {
-      MerchantID: parsed.MerchantID,
-      MerID: parsed.MerID,
-      MemberID: parsed.MemberID,
-      RequestNo: parsed.RequestNo,
-      StatusCode: parsed.StatusCode,
-      StatusDesc: parsed.StatusDesc,
-      ResponseTime: parsed.ResponseTime,
-      AuthCode: parsed.AuthCode ?? undefined,
-      ECI: parsed.ECI ?? undefined,
-      OrderNo: parsed.OrderNo ?? undefined,
-    };
-
-    if (result.StatusCode === '00') {
-      this._platformTradeNumber = result.OrderNo;
-      this.commit({
-        id: this.id,
-        totalPrice: this._amount,
-        memberId: this._memberId,
-        cardToken: this._cardToken,
-        committedAt: new Date(),
-      });
-
-      this._gateway.emitter.emit(PaymentEvents.ORDER_COMMITTED, this);
-
-      return {
-        success: true,
-        orderNo: result.OrderNo,
+      const result: CTBCOrderCommitResultPayload = {
+        MerchantID: parsed.MerchantID,
+        MerID: parsed.MerID,
+        MemberID: parsed.MemberID,
+        RequestNo: parsed.RequestNo,
+        StatusCode: parsed.StatusCode,
+        StatusDesc: parsed.StatusDesc,
+        ResponseTime: parsed.ResponseTime,
+        AuthCode: parsed.AuthCode ?? undefined,
+        ECI: parsed.ECI ?? undefined,
+        OrderNo: parsed.OrderNo ?? undefined,
       };
-    } else {
-      this.fail(result.StatusCode, result.StatusDesc);
+
+      if (result.StatusCode === '00') {
+        this._platformTradeNumber = result.OrderNo;
+        this.commit({
+          id: this.id,
+          totalPrice: this._amount,
+          memberId: this._memberId,
+          cardToken: this._cardToken,
+          committedAt: new Date(),
+        });
+
+        this._gateway.emitter.emit(PaymentEvents.ORDER_COMMITTED, this);
+
+        return {
+          success: true,
+          orderNo: result.OrderNo,
+        };
+      } else {
+        this.fail(result.StatusCode, result.StatusDesc);
+        this._gateway.emitter.emit(PaymentEvents.ORDER_FAILED, this);
+
+        return {
+          success: false,
+          error: {
+            code: result.StatusCode,
+            message: result.StatusDesc,
+          },
+        };
+      }
+    } catch (error) {
+      this.fail('MAC_FAIL', 'Invalid MAC in response');
       this._gateway.emitter.emit(PaymentEvents.ORDER_FAILED, this);
 
       return {
         success: false,
         error: {
-          code: result.StatusCode,
-          message: result.StatusDesc,
+          code: 'MAC_FAIL',
+          message: 'Invalid MAC in response',
         },
       };
     }

--- a/packages/payments-adapter-ctbc-micro-fast-pay/src/ctbc-payment.ts
+++ b/packages/payments-adapter-ctbc-micro-fast-pay/src/ctbc-payment.ts
@@ -96,10 +96,6 @@ export class CTBCPayment
       this.txnKey,
     );
 
-    if (!validateResponseMAC(toStringRecord(payload), this.txnKey)) {
-      throw new Error('MAC validation failed');
-    }
-
     const requestNo = payload.RequestNo;
 
     if (!this.bindCardRequestsCache.has(requestNo)) {


### PR DESCRIPTION
- Removed legacy validateResponseMAC logic based on sorted key-value pairs
- Simplified MAC verification to use decrypted TXN string directly
- Updated decodeResponsePayload to extract and validate MAC from decoded JSON
- This change aligns with CTBC spec: MAC should be based on original TXN string, not reordered
- Handled CTBC response payload that is URL-encoded hex of JSON
- Added URLSearchParams parsing to extract 'reqjsonpwd' from query string
- Replaced incorrect base64 decoding with hex decoding
- Added validation guard for missing reqjsonpwd
- Ensured all decrypted TXN fields are safely parsed even if value is missing