### PR TITLE
fix enable multiple language mode in category mutations and queries

### DIFF
--- a/packages/cms-base-nestjs-graphql-module/src/mutations/category.mutations.ts
+++ b/packages/cms-base-nestjs-graphql-module/src/mutations/category.mutations.ts
@@ -1,13 +1,45 @@
 import { Args, ID, Mutation, Resolver } from '@nestjs/graphql';
-import { CategoryBaseService } from '@rytass/cms-base-nestjs-module';
+import {
+  CategoryBaseService,
+  MULTIPLE_LANGUAGE_MODE,
+} from '@rytass/cms-base-nestjs-module';
 import { CreateCategoryArgs } from '../dto/create-category.args';
 import { IsPublic } from '@rytass/member-base-nestjs-module';
 import { BackstageCategoryDto } from '../dto/backstage-category.dto';
 import { UpdateCategoryArgs } from '../dto/update-category.args';
+import { Inject } from '@nestjs/common';
 
 @Resolver()
 export class CategoryMutations {
-  constructor(private readonly categoryService: CategoryBaseService) {}
+  constructor(
+    @Inject(MULTIPLE_LANGUAGE_MODE)
+    private readonly multiLanguage: boolean,
+    private readonly categoryService: CategoryBaseService,
+  ) {}
+
+  private resolveCreateCategoryArgs(args: CreateCategoryArgs) {
+    const basePayload = {
+      parentIds: args.parentIds,
+    };
+
+    if (!this.multiLanguage) {
+      const [content] = args.multiLanguageNames;
+
+      return {
+        ...basePayload,
+        name: content.name,
+      };
+    }
+
+    const multiLanguageNames = Object.fromEntries(
+      args.multiLanguageNames.map((name) => [name.language, name.name]),
+    );
+
+    return {
+      ...basePayload,
+      multiLanguageNames,
+    };
+  }
 
   @Mutation(() => BackstageCategoryDto)
   @IsPublic()
@@ -15,10 +47,7 @@ export class CategoryMutations {
     @Args() args: CreateCategoryArgs,
   ): Promise<BackstageCategoryDto> {
     return this.categoryService.create({
-      ...args,
-      multiLanguageNames: Object.fromEntries(
-        args.multiLanguageNames.map((name) => [name.language, name.name]),
-      ),
+      ...this.resolveCreateCategoryArgs(args),
     });
   }
 
@@ -28,10 +57,7 @@ export class CategoryMutations {
     @Args() args: UpdateCategoryArgs,
   ): Promise<BackstageCategoryDto> {
     return this.categoryService.update(args.id, {
-      ...args,
-      multiLanguageNames: Object.fromEntries(
-        args.multiLanguageNames.map((name) => [name.language, name.name]),
-      ),
+      ...this.resolveCreateCategoryArgs(args),
     });
   }
 


### PR DESCRIPTION
Implement support for multiple language handling in category creation and updates, as well as in category retrieval, enhancing the flexibility of the CMS.