### PR TITLE
Feat/payments adapter ctbc micro fast pay

### DIFF
--- a/packages/payments-adapter-ctbc-micro-fast-pay/src/ctbc-crypto.ts
+++ b/packages/payments-adapter-ctbc-micro-fast-pay/src/ctbc-crypto.ts
@@ -36,8 +36,8 @@ export function encodeRequestPayload(
   gateway: { merchantId: string; txnKey: string },
 ): string {
   const urlString = Object.entries(payload)
-    .filter(([_, value]) => value !== undefined)
-    .sort(([a], [b]) => a.localeCompare(b))
+    .filter(([_, v]) => v !== undefined)
+    .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
     .map(([k, v]) => `${k}=${v}`)
     .join('&');
 

--- a/packages/payments-adapter-ctbc-micro-fast-pay/src/ctbc-payment.ts
+++ b/packages/payments-adapter-ctbc-micro-fast-pay/src/ctbc-payment.ts
@@ -16,8 +16,6 @@ import {
 import { CTBCBindCardRequest } from './ctbc-bind-card-request';
 import {
   decodeResponsePayload,
-  toStringRecord,
-  validateResponseMAC,
 } from './ctbc-response';
 
 export class CTBCPayment

--- a/packages/payments-adapter-ctbc-micro-fast-pay/src/ctbc-payment.ts
+++ b/packages/payments-adapter-ctbc-micro-fast-pay/src/ctbc-payment.ts
@@ -16,6 +16,8 @@ import {
 import { CTBCBindCardRequest } from './ctbc-bind-card-request';
 import {
   decodeResponsePayload,
+  toStringRecord,
+  validateResponseMAC,
 } from './ctbc-response';
 
 export class CTBCPayment
@@ -51,7 +53,11 @@ export class CTBCPayment
   createBindCardRequest(
     payload: CTBCBindCardRequestPayload,
   ): CTBCBindCardRequest {
-    return new CTBCBindCardRequest(payload, this);
+    const request = new CTBCBindCardRequest(payload, this);
+
+    this.bindCardRequestsCache.set(payload.RequestNo, request);
+
+    return request;
   }
 
   async prepare<N extends CTBCOrderCommitMessage>(

--- a/packages/payments-adapter-ctbc-micro-fast-pay/src/ctbc-response.ts
+++ b/packages/payments-adapter-ctbc-micro-fast-pay/src/ctbc-response.ts
@@ -17,7 +17,7 @@ export function decodeResponsePayload<T = Record<string, string>>(
     throw new Error('Missing encoded response payload');
   }
 
-  const json = decodeURIComponent(decodeURIComponent(rawResponseKey));
+  const json = decodeURIComponent(rawResponseKey);
   const response = JSON.parse(json);
 
   const { MAC, TXN } = response.Response.Data;


### PR DESCRIPTION
- Created a `CTBCBindCardRequest` instance from the payload and current context
- Stored the instance in `bindCardRequestsCache` using `RequestNo` as the key
- Ensured the instance is returned as before
- Removed unused imports `toStringRecord` and `validateResponseMAC` from `ctbc-response`
- Validation logic is now handled inside `decodeResponsePayload` with try-catch for cleaner error handling
- Removed second decodeURIComponent call when parsing raw response key
- CTBC response payload is only encoded once; double decoding caused JSON parse issues
- Ensures correct decoding and parsing of response JSON structure
- Replaced localeCompare with strict ASCII comparison in payload key sorting
- Aligns with CTBC spec requiring ASCII-ordered URL string before encryption
- Added debug logs for raw payload, URL string, MAC, and final encrypted data