### PR TITLE
Feat/payments adapter newebpay tcc

### DIFF
--- a/packages/logistics-adapter-ctc/CHANGELOG.md
+++ b/packages/logistics-adapter-ctc/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.2.3](https://github.com/Rytass/Utils/compare/@rytass/logistics-adapter-ctc@0.2.2...@rytass/logistics-adapter-ctc@0.2.3) (2025-07-17)
+
+### Features
+
+- **logistics-adapter-ctc:** update createOrUpdate input interface ([b7b96cb](https://github.com/Rytass/Utils/commit/b7b96cbca6459772c8a7c31aa2e8671147a4a3a0))
+
 ## 0.2.2 (2025-06-25)
 
 ### Features

--- a/packages/logistics-adapter-ctc/__tests__/delivery-adapter-ctc.spec.ts
+++ b/packages/logistics-adapter-ctc/__tests__/delivery-adapter-ctc.spec.ts
@@ -1,6 +1,6 @@
 
 import { LogisticsError } from '@rytass/logistics';
-import { CtcLogisticsService, CtcLogistics } from '../src';
+import { CtcLogisticsService, CtcLogistics, CreateOrUpdateCtcLogisticsOptions } from '../src';
 import axios from 'axios';
 
 describe('delivery-adapter-ctc', () => {
@@ -88,7 +88,8 @@ describe('delivery-adapter-ctc', () => {
     const get = jest.spyOn(axios, 'get');
 
     const createOrUpdateCtcLogisticsOptions = {
-      trackingNumber: 'R25061100009', // 查件單號
+      shippingNumber: 'R25071700027', // 托運單號
+      trackingNumber: 'ABCD202507170001', // 查件單號
       senderCompany: 'Sender Name',
       senderMobile: '1234567890',
       senderAddress: 'Sender Address',
@@ -112,7 +113,7 @@ describe('delivery-adapter-ctc', () => {
       quantity: 1, // 件數, 固定為 1
       weight: 1, // 重量, 固定為 1
       volume: 1, // 材積, 固定為 1
-    };
+    } as CreateOrUpdateCtcLogisticsOptions;
 
     post.mockImplementation(async (url: string, data: any) => {
       expect(url).toBe('https://tms2.ctc-express.cloud/api/v1/customer/orders');
@@ -120,8 +121,8 @@ describe('delivery-adapter-ctc', () => {
       return {
         data: {
           success: true,
-          shipping_number: 'R25061100009測試',
-          tracking_number: 'R25061100009',
+          shipping_number: 'R25071700027',
+          tracking_number: 'ABCD202507170001',
         },
       };
     });

--- a/packages/logistics-adapter-ctc/package.json
+++ b/packages/logistics-adapter-ctc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rytass/logistics-adapter-ctc",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Rytass Utils Logistics ctc adapter",
   "keywords": [
     "rytass",

--- a/packages/logistics-adapter-ctc/src/logistics-adapter-ctc.ts
+++ b/packages/logistics-adapter-ctc/src/logistics-adapter-ctc.ts
@@ -140,8 +140,9 @@ export class CtcLogisticsService<
 
     const requestBody: CreateOrUpdateCtcLogisticsRequest = {
       order: {
-        tracking_number: options.trackingNumber,
+        tracking_number: options.trackingNumber, // 建立可指定查件單號, 更新時可帶入托運單號做更新
         customer_department_id: options.customerDepartmentId,
+        customer_department_unit_id: options.customerDepartmentUnitId,
 
         sender_company: options.senderCompany,
         sender_contact_name: options.senderContactName ?? options.senderCompany,
@@ -160,7 +161,7 @@ export class CtcLogisticsService<
         shipment_content: options.shipmentContent ?? '貨件', // 固定為 '貨件'
         transportation: options.transportation ?? 'truck', // 固定為 'truck'
         shipping_method: options.shippingMethod ?? 'land', // 固定為 'land'
-        payer: options.payer ?? 'sender', // 固定為 'sender'
+        payer: options.payer ?? 'receiver', // 固定為 'receiver'
         shipping_time: options.shippingTime ?? 'regular', // 固定為 'regular'
         payment_method: options.paymentMethod ?? 'monthly', // 固定為 'monthly'
         quantity: options.quantity ?? 1, // 固定為 1
@@ -186,7 +187,7 @@ export class CtcLogisticsService<
       }
 
       return {
-        trackingNumber: data.tracking_number ?? options.trackingNumber,
+        trackingNumber: data.tracking_number,
         shippingNumber: data.shipping_number,
       }
     } catch (err) {

--- a/packages/logistics-adapter-ctc/src/typings.ts
+++ b/packages/logistics-adapter-ctc/src/typings.ts
@@ -66,8 +66,9 @@ export const CtcLogistics: CtcLogisticsInterface<CtcLogisticsStatus> = {
 }
 
 export interface CreateOrUpdateCtcLogisticsOptions {
-  trackingNumber: string; // 查件單號, primary key
-  customerDepartmentId: number; // 客戶部門ID, optional
+  trackingNumber?: string; // 查件單號, primary key
+  customerDepartmentId?: number; // 客戶部門ID, optional
+  customerDepartmentUnitId?: number; // 客戶部門單位ID, optional
 
   senderCompany: string; // 寄件人公司名稱
   senderContactName?: string; // 寄件人聯絡人
@@ -95,14 +96,15 @@ export interface CreateOrUpdateCtcLogisticsOptions {
 }
 
 export interface CtcLogisticsDto {
-  trackingNumber: string; // 查件單號
+  trackingNumber?: string; // 查件單號
   shippingNumber: string; // 托運單號
 }
 
 export interface CreateOrUpdateCtcLogisticsRequest {
   order: {
-    tracking_number: string; // 查件單號
-    customer_department_id: number; // 客戶部門ID
+    tracking_number?: string; // 查件單號
+    customer_department_id?: number; // 客戶部門ID, optional
+    customer_department_unit_id?: number; // 客戶部門單位ID, optional
 
     sender_company: string; // 寄件人公司名稱
     sender_contact_name: string; // 寄件人聯絡人

--- a/packages/payments-adapter-newebpay-tcc/CHANGELOG.md
+++ b/packages/payments-adapter-newebpay-tcc/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Change Log

--- a/packages/payments-adapter-newebpay-tcc/README.md
+++ b/packages/payments-adapter-newebpay-tcc/README.md
@@ -1,0 +1,1 @@
+# Rytass Utils - Payments (NewebPay TCC)

--- a/packages/payments-adapter-newebpay-tcc/docs/NewebPay-Usage.md
+++ b/packages/payments-adapter-newebpay-tcc/docs/NewebPay-Usage.md
@@ -1,0 +1,155 @@
+# NewebPay TCC Adapter 使用說明
+
+本模組提供與藍新金流 NewebPay 平台整合之信用卡綁定與約定付款（TCC）流程，支援首次綁卡、定期或非定期付款、查詢、解綁，並支援事件導向開發模式，與 CTBC Adapter 結構一致。
+
+---
+
+## 📌 目錄
+
+- [模組總覽](#模組總覽)
+- [初始化說明](#初始化說明)
+- [綁卡流程](#綁卡流程)
+- [付款流程](#付款流程)
+- [查詢與解綁](#查詢與解綁)
+- [事件監聽](#事件監聽)
+
+---
+
+## 模組總覽
+
+```ts
+NewebPayPayment             // 主 Gateway，統一提供綁卡與付款服務
+├─ createBindCardRequest    // 建立綁卡 Request，產生 form/formHTML
+├─ handleBindCardCallback   // 處理 NewebPay 綁卡 callback
+├─ createOrder              // 建立訂單並準備 commit
+├─ queryBindCard            // 查詢指定 Token 是否有效
+├─ unbindCard               // 解綁卡片
+├─ emitter                  // 派發事件：CARD_BOUND、ORDER_COMMITTED...
+```
+
+---
+
+## 初始化說明
+
+```ts
+const payment = new NewebPayPayment({
+  merchantId: 'YourMerchantID',
+  aesKey: 'YourKeyFromNewebPay',
+  aesIv: 'YourIVFromNewebPay',
+  encryptType: 0, // 0 = CBC, 1 = GCM
+});
+```
+
+---
+
+## 綁卡流程
+
+> 首次授權
+
+1. 建立綁卡請求：
+
+```ts
+const bindCardRequest = payment.createBindCardRequest({
+  MerchantID: 'YourMerchantID',
+  Version: '1.0',
+  RespondType: 'JSON',
+  TimeStamp: Date.now().toString(),
+  MerchantOrderNo: 'ORD20240718001',
+  Amt: 1,
+  Email: 'user@example.com',
+  LoginType: 0,
+  TokenTerm: 'U0001',
+  TokenLife: 9999,
+  NotifyURL: 'https://your.site/callback',
+});
+```
+
+2. 將 `bindCardRequest.formHTML` 回傳前端，直接跳轉 NewebPay 綁卡畫面。
+
+3. 綁卡完成後，NewebPay 將以 POST 傳送 `TradeInfo`, `TradeSha` 至 `NotifyURL`
+
+4. 後端處理 callback：
+
+```ts
+await payment.handleBindCardCallback(tradeInfo, tradeSha);
+```
+
+5. 成功後觸發事件：
+
+```ts
+payment.emitter.on(PaymentEvents.CARD_BOUND, (request) => {
+  console.log(request.tokenValue, request.cardNumberPrefix, request.bindingDate);
+});
+```
+
+---
+
+## 付款流程
+
+> 後續約定付款
+
+1. 建立付款訂單：
+
+```ts
+const order = payment.createOrder({
+  MerchantOrderNo: 'ORD20240718099',
+  Amt: 500,
+  ItemDesc: '月費扣款',
+  Email: 'user@example.com',
+  TokenValue: 'TOKENXXXXXX',
+  TokenTerm: 'U0001',
+});
+```
+
+2. 執行請款：
+
+```ts
+const result = await order.executeCommit();
+
+if (result.success) {
+  console.log('請款成功，交易號：', result.orderNo);
+} else {
+  console.error('請款失敗：', result.error?.code, result.error?.message);
+}
+```
+
+---
+
+## 查詢與解綁
+
+### 查詢綁卡狀態
+
+```ts
+const card = await payment.queryBindCard('U0001', 'TOKENXXXXXX');
+
+console.log(card.card6No, card.card4No, card.valid, card.tokenSwitch);
+```
+
+### 解綁卡片
+
+```ts
+const result = await payment.unbindCard('U0001', 'TOKENXXXXXX');
+
+console.log(result.success); // true / false
+```
+
+---
+
+## 事件監聽
+
+```ts
+payment.emitter.on(PaymentEvents.CARD_BOUND, (request) => { ... });
+payment.emitter.on(PaymentEvents.CARD_BINDING_FAILED, (request) => { ... });
+
+payment.emitter.on(PaymentEvents.ORDER_COMMITTED, (order) => { ... });
+payment.emitter.on(PaymentEvents.ORDER_FAILED, (order) => { ... });
+```
+
+---
+
+## 備註
+
+- 綁卡流程屬一次性綁定，需由前端引導跳轉 NewebPay 頁面。
+- 綁卡完成後可使用 `TokenValue` 執行背景請款或排程扣款。
+- 僅支援幕後 API（NPA-B101 / B102 / B103 / B104）與前台 P1（NPA-F011）。
+

--- a/packages/payments-adapter-newebpay-tcc/package.json
+++ b/packages/payments-adapter-newebpay-tcc/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@rytass/payments-adapter-newebpay-tcc",
+  "version": "0.0.7",
+  "description": "Rytass Payment Gateway",
+  "keywords": [
+    "rytass",
+    "payment"
+  ],
+  "author": "Chia Yu Pai <fantasyatelier@gmail.com>",
+  "homepage": "https://github.com/Rytass/Utils#readme",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+ssh://git@github.com/Rytass/Utils.git"
+  },
+  "scripts": {
+    "clean": "npm run build:clean",
+    "build:clean": "node ../../scripts/cleanBuild.js",
+    "build": "npm run build:clean && node ../../scripts/build.js"
+  },
+  "main": "./lib/index.cjs.js",
+  "bugs": {
+    "url": "https://github.com/Rytass/Utils/issues"
+  },
+  "dependencies": {
+    "@rytass/payments": "^0.1.6",
+    "axios": "^1.7.8",
+    "debug": "^4.3.7",
+    "lru-cache": "^11.0.2",
+    "luxon": "^3.5.0",
+    "ngrok": "^4.3.3"
+  },
+  "devDependencies": {
+    "@types/debug": "^4.1.12",
+    "@types/lru-cache": "^7.10.10",
+    "@types/luxon": "^3.4.2"
+  }
+}

--- a/packages/payments-adapter-newebpay-tcc/src/index.ts
+++ b/packages/payments-adapter-newebpay-tcc/src/index.ts
@@ -1,0 +1,1 @@
+export * from '@rytass/payments';

--- a/packages/payments-adapter-newebpay-tcc/src/index.ts
+++ b/packages/payments-adapter-newebpay-tcc/src/index.ts
@@ -1,1 +1,16 @@
+export { NewebPayBindCardRequestState, NewebPayOrderState } from './typings';
+
+export type {
+  NewebPayBindCardRequestPayload,
+  NewebPayBindCardResult,
+  NewebPayOrderInput,
+  NewebPayOrderCommitMessage,
+  NewebPayOrderCommitResult,
+  NewebPayPaymentOptions,
+} from './typings';
+
+export { NewebPayBindCardRequest } from './newebpay-bind-card-request';
+export { NewebPayOrder } from './newebpay-order';
+export { NewebPayPayment } from './newebpay-payment';
+
 export * from '@rytass/payments';

--- a/packages/payments-adapter-newebpay-tcc/src/newebpay-bind-card-request.ts
+++ b/packages/payments-adapter-newebpay-tcc/src/newebpay-bind-card-request.ts
@@ -1,0 +1,163 @@
+/**
+ * NewebPayBindCardRequest
+ * --------------------------------------------------
+ * 封裝「首次約定付款 (P1) 綁卡流程」之 Request 物件。
+ * 產生提交表單 (TradeInfo/TradeSha) 與 HTML，並追蹤綁卡狀態。
+ *
+ * ⚠️ 僅聚焦流程本身；Gateway (NewebPayPayment) 將負責
+ * - 提供 encode Key/IV
+ * - 監聽伺服器並回呼 bound() / fail()
+ */
+
+import { PaymentEvents } from '@rytass/payments';
+import { DateTime } from 'luxon';
+import { buildTradeInfo, EncodeOptions } from './newebpay-crypto';
+import { NewebPayBindCardRequestPayload, NewebPayBindCardRequestState, NewebPayBindCardResult, TradeInfoResult } from './typings';
+import { EventEmitter } from 'node:events';
+
+export class NewebPayBindCardRequest {
+  /* raw P1 payload (ASCII→AES 前) */
+  private readonly _payload: NewebPayBindCardRequestPayload;
+
+  /* gateway 資訊 (僅用於 baseUrl 與 encode key/iv、事件派送) */
+  private readonly _encodeOpts: EncodeOptions;
+  private readonly _emitter: EventEmitter;
+  private readonly _mpgEndpoint: string;
+
+  /* state tracking */
+  private _resolved = false;
+  private _state = NewebPayBindCardRequestState.INITED;
+
+  /* after bound */
+  private _tokenValue?: string;
+  private _card6?: string;
+  private _card4?: string;
+  private _bindingDate?: Date;
+  private _failedCode?: string;
+  private _failedMsg?: string;
+
+  constructor(
+    payload: NewebPayBindCardRequestPayload,
+    encodeOpts: EncodeOptions,
+    emitter: EventEmitter,
+    mpgEndpoint = 'https://ccore.newebpay.com/MPG/mpg_gateway',
+  ) {
+    this._payload = payload;
+    this._encodeOpts = encodeOpts;
+    this._emitter = emitter;
+    this._mpgEndpoint = mpgEndpoint;
+  }
+
+  /* ------------------------------------------------------------------ */
+  /* Basic getters */
+  /* ------------------------------------------------------------------ */
+
+  get tokenValue(): string | undefined {
+    return this._tokenValue;
+  }
+  get cardNumberPrefix(): string | undefined {
+    return this._card6;
+  }
+  get cardNumberSuffix(): string | undefined {
+    return this._card4;
+  }
+  get bindingDate(): Date | undefined {
+    return this._bindingDate;
+  }
+  get state(): NewebPayBindCardRequestState {
+    return this._state;
+  }
+  get failedMessage():
+    | { code: string; message: string }
+    | null {
+    if (!this._failedCode) return null;
+
+    return { code: this._failedCode, message: this._failedMsg! };
+  }
+
+  /* ------------------------------------------------------------------ */
+  /* Form & HTML */
+  /* ------------------------------------------------------------------ */
+
+  /** 回傳提交綁卡用的表單欄位 (P1 前台) */
+  get form(): Record<string, string | number> {
+    if (this._state !== NewebPayBindCardRequestState.INITED)
+      throw new Error('Form already generated');
+
+    const { TradeInfo, TradeSha, EncryptType } = buildTradeInfo(
+      this._payload,
+      this._encodeOpts,
+    );
+
+    this._state = NewebPayBindCardRequestState.FORM_GENERATED;
+
+    const baseFields: TradeInfoResult = {
+      TradeInfo,
+      TradeSha,
+      EncryptType,
+    };
+
+    return {
+      MerchantID: this._payload.MerchantID,
+      Version: this._payload.Version,
+      RespondType: this._payload.RespondType,
+      ...baseFields,
+    };
+  }
+
+  /** 產生自動 submit 的 HTML (方便後端返回前端直接跳轉) */
+  get formHTML(): string {
+    const formFields = this.form;
+
+    const inputs = Object.entries(formFields)
+      .map(
+        ([k, v]) => `<input type="hidden" name="${k}" value="${v}" />`,
+      )
+      .join('\n      ');
+
+    return `<!DOCTYPE html>
+<html>
+  <body onload="document.forms[0].submit();">
+    <form action="${this._mpgEndpoint}" method="post">
+      ${inputs}
+    </form>
+  </body>
+</html>`;
+  }
+
+  /* ------------------------------------------------------------------ */
+  /* Callback handlers – called by Gateway */
+  /* ------------------------------------------------------------------ */
+
+  /**
+   * 處理綁卡成功
+   */
+  bound(result: NewebPayBindCardResult): void {
+    this._tokenValue = result.TokenValue;
+    this._card6 = result.Card6No;
+    this._card4 = result.Card4No;
+    this._bindingDate = DateTime.fromFormat(
+      result.PayTime,
+      'yyyy-MM-dd HH:mm:ss',
+    ).toJSDate();
+
+    this._state = NewebPayBindCardRequestState.BOUND;
+
+    this._emitter.emit(PaymentEvents.CARD_BOUND, this);
+  }
+
+  /**
+   * 處理綁卡失敗
+   */
+  fail(code: string, message: string, maybeResult?: Partial<NewebPayBindCardResult>): void {
+    this._failedCode = code;
+    this._failedMsg = message;
+    this._state = NewebPayBindCardRequestState.FAILED;
+
+    if (maybeResult?.TokenValue) this._tokenValue = maybeResult.TokenValue;
+    if (maybeResult?.Card6No) this._card6 = maybeResult.Card6No;
+    if (maybeResult?.Card4No) this._card4 = maybeResult.Card4No;
+
+    this._emitter.emit(PaymentEvents.CARD_BINDING_FAILED, this);
+  }
+}

--- a/packages/payments-adapter-newebpay-tcc/src/newebpay-crypto-core.ts
+++ b/packages/payments-adapter-newebpay-tcc/src/newebpay-crypto-core.ts
@@ -1,0 +1,108 @@
+/*
+ * NewebPay Crypto Core
+ * --------------------------------------------------
+ * Encapsulates low-level AES (CBC/GCM) encryption & SHA-256 hashing helpers
+ * used across payments-adapter-newebpay-tcc.
+ *
+ * - AES key & IV come from NewebPay merchant backend ("Key", "IV").
+ * - CBC mode uses PKCS#7 padding; GCM mode relies on built-in padding.
+ * - All hex outputs are **uppercase** (NewebPay spec).
+ */
+
+import crypto from 'node:crypto';
+
+// #region ─────────────────────────── Types ───────────────────────────
+export type AesMode = 'CBC' | 'GCM';
+
+// #endregion
+
+// #region ───────────────────────── Helpers ───────────────────────────
+function pkcs7Pad(buf: Buffer, blockSize = 16): Buffer {
+  const pad = blockSize - (buf.length % blockSize);
+
+  return Buffer.concat([buf, Buffer.alloc(pad, pad)]);
+}
+
+function pkcs7Unpad(buf: Buffer): Buffer {
+  const pad = buf[buf.length - 1];
+
+  if (pad <= 0 || pad > 16) throw new Error('Invalid PKCS#7 padding');
+
+  return buf.subarray(0, buf.length - pad);
+}
+
+/**
+ * Produce SHA-256 hex (uppercase)
+ */
+export function sha256Hex(data: crypto.BinaryLike): string {
+  return crypto.createHash('sha256').update(data).digest('hex').toUpperCase();
+}
+
+// #endregion
+
+// #region ───────────────────── AES Encrypt / Decrypt ──────────────────
+
+export function encryptAES(
+  plaintext: string | Buffer,
+  key: string | Buffer,
+  iv: string | Buffer,
+  mode: AesMode = 'CBC',
+): Buffer {
+  const _key = typeof key === 'string' ? Buffer.from(key, 'utf8') : key;
+  const _iv = typeof iv === 'string' ? Buffer.from(iv, 'utf8') : iv;
+  const cipherName = mode === 'CBC' ? 'aes-256-cbc' : 'aes-256-gcm';
+
+  const cipher = crypto.createCipheriv(cipherName, _key, _iv) as crypto.CipherGCM;
+  let input = typeof plaintext === 'string' ? Buffer.from(plaintext, 'utf8') : plaintext;
+
+  if (mode === 'CBC') input = pkcs7Pad(input);
+
+  const encrypted = Buffer.concat([cipher.update(input), cipher.final()]);
+
+  return mode === 'GCM' ? Buffer.concat([encrypted, cipher.getAuthTag()]) : encrypted;
+}
+
+export function decryptAES(
+  ciphertext: Buffer,
+  key: string | Buffer,
+  iv: string | Buffer,
+  mode: AesMode = 'CBC',
+): Buffer {
+  const _key = typeof key === 'string' ? Buffer.from(key, 'utf8') : key;
+  const _iv = typeof iv === 'string' ? Buffer.from(iv, 'utf8') : iv;
+  const cipherName = mode === 'CBC' ? 'aes-256-cbc' : 'aes-256-gcm';
+
+  let data = ciphertext;
+  let authTag: Buffer | undefined;
+
+  if (mode === 'GCM') {
+    authTag = data.subarray(data.length - 16);
+    data = data.subarray(0, data.length - 16);
+  }
+
+  const decipher = crypto.createDecipheriv(cipherName, _key, _iv) as crypto.DecipherGCM;
+
+  if (authTag) {
+    (decipher as crypto.DecipherGCM).setAuthTag(authTag);
+  }
+
+  const decrypted = Buffer.concat([decipher.update(data), decipher.final()]);
+
+  return mode === 'CBC' ? pkcs7Unpad(decrypted) : decrypted;
+}
+
+// #endregion
+
+// #region ───────────────────────── CheckCode ──────────────────────────
+/**
+ * 依附錄四演算法產生 CheckCode (HashData / TradeSha)
+ * 公式：SHA256(`HashKey=${key}&${hexStr}&HashIV=${iv}`) → hex
+ *
+ * @param encryptedHex  AES 加密後的 **HEX 字串** (大小寫不限)
+ */
+export function generateHashData(encryptedHex: string, key: string, iv: string): string {
+  const raw = `HashKey=${key}&${encryptedHex}&HashIV=${iv}`;
+
+  return sha256Hex(raw).toUpperCase();
+}
+// #endregion

--- a/packages/payments-adapter-newebpay-tcc/src/newebpay-crypto.ts
+++ b/packages/payments-adapter-newebpay-tcc/src/newebpay-crypto.ts
@@ -1,10 +1,10 @@
 /*
  * NewebPay Crypto – Request / Response helpers
  * --------------------------------------------------
- * 將欄位物件 → ASCII 排序 → URL 查詢字串
- *   ↳ AES 加密 (EncryptData / TradeInfo)
- *   ↳ SHA256 雜湊 (HashData / TradeSha)
- * 解析回傳：驗證 Hash → AES 解開 → 轉回物件
+ * Transforms a field object → ASCII-sorted → URL query string
+ *   ↳ AES encryption (EncryptData / TradeInfo)
+ *   ↳ SHA256 hashing (HashData / TradeSha)
+ * Parses response: verify hash → decrypt AES → convert back to object
  */
 
 import { encryptAES, decryptAES, generateHashData, sha256Hex, AesMode } from './newebpay-crypto-core';

--- a/packages/payments-adapter-newebpay-tcc/src/newebpay-crypto.ts
+++ b/packages/payments-adapter-newebpay-tcc/src/newebpay-crypto.ts
@@ -1,0 +1,101 @@
+/*
+ * NewebPay Crypto – Request / Response helpers
+ * --------------------------------------------------
+ * 將欄位物件 → ASCII 排序 → URL 查詢字串
+ *   ↳ AES 加密 (EncryptData / TradeInfo)
+ *   ↳ SHA256 雜湊 (HashData / TradeSha)
+ * 解析回傳：驗證 Hash → AES 解開 → 轉回物件
+ */
+
+import { encryptAES, decryptAES, generateHashData, sha256Hex, AesMode } from './newebpay-crypto-core';
+import { PostDataResult, TradeInfoResult } from './typings';
+
+// #region ──────────────────────── Types ─────────────────────────
+export interface EncodeOptions {
+  key: string; // 商店 Key
+  iv: string;  // 商店 IV
+  encryptType?: 0 | 1; // 0 = AES/CBC, 1 = AES/GCM (文件 EncryptType)
+}
+
+export interface EncodeResult {
+  encrypted: string; // HEX (大寫)
+  hash: string;      // SHA256 Hex (大寫)
+}
+
+// #endregion
+
+// #region ──────────────────── Core Utilities ───────────────────
+
+/**
+ * 將物件轉為 ASCII 排序之 URL 字串 (k1=v1&k2=v2…)
+ */
+export function toSortedQuery(payload: Record<string, unknown>): string {
+  return Object.entries(payload)
+    .filter(([, v]) => v !== undefined)
+    .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+    .map(([k, v]) => `${k}=${v}`)
+    .join('&');
+}
+
+/**
+ * Encode payload for NewebPay (TradeInfo / EncryptData)
+ */
+export function encodePayload(payload: Record<string, unknown>, opts: EncodeOptions): EncodeResult {
+  const query = toSortedQuery(payload);
+  const mode: AesMode = opts.encryptType === 1 ? 'GCM' : 'CBC';
+  const encryptedBuf = encryptAES(query, opts.key, opts.iv, mode);
+  const encryptedHex = encryptedBuf.toString('hex').toUpperCase();
+  const hash = generateHashData(encryptedHex, opts.key, opts.iv);
+
+  return { encrypted: encryptedHex, hash };
+}
+
+/**
+ * Decode and verify NewebPay response (EncryptData / TradeInfo)
+ */
+export function decodePayload(encryptedHex: string, hash: string, opts: EncodeOptions): Record<string, string> {
+  const expectHash = generateHashData(encryptedHex, opts.key, opts.iv);
+
+  if (expectHash !== hash.toUpperCase()) throw new Error('Hash verification failed');
+
+  const mode: AesMode = opts.encryptType === 1 ? 'GCM' : 'CBC';
+  const decryptedBuf = decryptAES(Buffer.from(encryptedHex, 'hex'), opts.key, opts.iv, mode);
+  const query = decryptedBuf.toString('utf8');
+
+  const obj: Record<string, string> = {};
+
+  for (const kv of query.split('&')) {
+    const [k, v] = kv.split('=');
+
+    obj[k] = v;
+  }
+
+  return obj;
+}
+
+// #endregion
+
+// #region ────────────────── High‑level wrappers ──────────────────
+
+/**
+ * For P1 (前台) – TradeInfo + TradeSha
+ */
+export function buildTradeInfo(payload: Record<string, unknown>, opts: EncodeOptions):TradeInfoResult {
+  const { encrypted, hash } = encodePayload(payload, opts);
+
+  return { TradeInfo: encrypted, TradeSha: hash, EncryptType: opts.encryptType ?? 0 };
+}
+
+/**
+ * For P1/Pn (幕後) – PostData_ / EncryptData_/HashData_
+ */
+export function buildPostData(payload: Record<string, unknown>, opts: EncodeOptions):PostDataResult {
+  const { encrypted, hash } = encodePayload(payload, opts);
+
+  return {
+    PostData_: { EncryptData: encrypted, HashData: hash },
+    EncryptType_: opts.encryptType ?? 0,
+  };
+}
+
+// #endregion

--- a/packages/payments-adapter-newebpay-tcc/src/newebpay-order.ts
+++ b/packages/payments-adapter-newebpay-tcc/src/newebpay-order.ts
@@ -1,0 +1,161 @@
+/**
+ * NewebPayOrder (Pn)
+ * --------------------------------------------------
+ * 封裝 NPA-B102「後續約定付款」邏輯。
+ *
+ * 流程：
+ *   1. Gateway.createOrder(...) → new NewebPayOrder
+ *   2. client 呼叫 order.executeCommit()
+ *   3. 本檔案組合 PostData_ (AES/CBC+SHA256) 並送往 /API/CreditCard
+ *   4. 解析回傳、驗證 Hash，更新 state 與派發事件
+ */
+
+import { Order, OrderState, PaymentEvents } from '@rytass/payments';
+import { encodePayload } from './newebpay-crypto';
+import { NewebPayPayment } from './newebpay-payment';
+import { decodeEncryptData } from './newebpay-response';
+
+import {
+  AdditionalInfo,
+  AsyncOrderInformation,
+  OrderFailMessage,
+  PaymentItem,
+} from '@rytass/payments';
+import {
+  NewebPayOrderCommitMessage,
+  NewebPayOrderCommitResult,
+  NewebPayOrderInput,
+  PnEncryptData,
+} from './typings';
+
+export class NewebPayOrder implements Order<NewebPayOrderCommitMessage> {
+  readonly id: string;
+  readonly createdAt: Date = new Date();
+  committedAt: Date | null = null;
+  state: OrderState = OrderState.INITED;
+
+  /** T / V */
+  private readonly tokenTerm: string;
+  private readonly tokenValue: string;
+
+  private readonly amount: number;
+  private readonly description?: string;
+
+  private readonly _gateway: NewebPayPayment;
+
+  items: PaymentItem[] = [];
+  additionalInfo?: AdditionalInfo<NewebPayOrderCommitMessage>;
+  asyncInfo?: AsyncOrderInformation<NewebPayOrderCommitMessage>;
+  failedMessage: OrderFailMessage | null = null;
+
+  constructor(input: NewebPayOrderInput, gateway: NewebPayPayment) {
+    this.id = input.id;
+    this.tokenTerm = input.tokenTerm;
+    this.tokenValue = input.tokenValue;
+    this.amount = input.amount;
+    this.description = input.description;
+    this._gateway = gateway;
+  }
+
+  get committable(): boolean {
+    return this.state === OrderState.INITED && !this.failedMessage;
+  }
+
+  infoRetrieved(info: AsyncOrderInformation<NewebPayOrderCommitMessage>): void {
+    this.asyncInfo = info;
+    this.state = OrderState.ASYNC_INFO_RETRIEVED;
+    this._gateway._emitter.emit(PaymentEvents.ORDER_INFO_RETRIEVED, this);
+  }
+
+  fail(code: string, message: string): void {
+    this.failedMessage = { code, message };
+    this.state = OrderState.FAILED;
+  }
+
+  commit(
+    message: NewebPayOrderCommitMessage,
+    addInfo?: AdditionalInfo<NewebPayOrderCommitMessage>,
+  ): void {
+    this.committedAt = message.committedAt;
+    this.state = OrderState.COMMITTED;
+    this.additionalInfo = addInfo;
+  }
+
+  async refund(): Promise<void> {
+    throw new Error('Refund not implemented for NewebPayOrder');
+  }
+
+  /* ------------------------------------------------------------------ */
+  /* Execute commit (send Pn)                                           */
+  /* ------------------------------------------------------------------ */
+
+  async executeCommit(): Promise<NewebPayOrderCommitResult> {
+    if (this.state !== OrderState.INITED)
+      throw new Error('Order already committed');
+
+    // Build payload for AES encode (PostData_)
+    const payload = {
+      MerchantID: this._gateway.merchantId,
+      TimeStamp: Math.floor(Date.now() / 1000),
+      Version: '2.1',
+      Amt: this.amount,
+      TokenTerm: this.tokenTerm,
+      TokenValue: this.tokenValue,
+      MerchantOrderNo: this.id,
+    };
+
+    const { encrypted: EncryptData, hash: HashData } = encodePayload(
+      payload,
+      this._gateway.encodeOpts,
+    );
+
+    // Form fields for /API/CreditCard
+    const resp = await this._gateway['postForm']<{
+      EncryptData: string;
+      HashData: string;
+    }>('/API/CreditCard', {
+      MerchantID_: this._gateway.merchantId,
+      PostData_: EncryptData,
+      Pos_: 'JSON',
+    });
+
+    let result: NewebPayOrderCommitResult;
+
+    try {
+      const data = decodeEncryptData(
+        resp,
+        this._gateway.encodeOpts,
+      ) as unknown as PnEncryptData;
+
+      if (data.Status === 'SUCCESS') {
+        this.state = OrderState.COMMITTED;
+        this.committedAt = new Date(data.PayTime.replace(/-/g, '/'));
+        result = {
+          success: true,
+          tradeNo: data.TradeNo,
+          payTime: data.PayTime,
+        };
+
+        this._gateway._emitter.emit(PaymentEvents.ORDER_COMMITTED, this);
+      } else {
+        this.state = OrderState.FAILED;
+        result = {
+          success: false,
+          error: { code: data.Status, message: data.Message },
+        };
+
+        this._gateway._emitter.emit(PaymentEvents.ORDER_FAILED, this);
+      }
+    } catch (err: any) {
+      this.state = OrderState.FAILED;
+      result = {
+        success: false,
+        error: { code: 'DECODE_FAIL', message: err.message },
+      };
+
+      this._gateway._emitter.emit(PaymentEvents.ORDER_FAILED, this);
+    }
+
+    return result;
+  }
+}

--- a/packages/payments-adapter-newebpay-tcc/src/newebpay-order.ts
+++ b/packages/payments-adapter-newebpay-tcc/src/newebpay-order.ts
@@ -1,13 +1,13 @@
 /**
  * NewebPayOrder (Pn)
  * --------------------------------------------------
- * 封裝 NPA-B102「後續約定付款」邏輯。
+ * Encapsulates the NPA-B102 "Subsequent Scheduled Payment" flow.
  *
- * 流程：
+ * Flow:
  *   1. Gateway.createOrder(...) → new NewebPayOrder
- *   2. client 呼叫 order.executeCommit()
- *   3. 本檔案組合 PostData_ (AES/CBC+SHA256) 並送往 /API/CreditCard
- *   4. 解析回傳、驗證 Hash，更新 state 與派發事件
+ *   2. Client calls order.executeCommit()
+ *   3. This file constructs PostData_ (AES/CBC + SHA256) and sends it to /API/CreditCard
+ *   4. Parses response, verifies hash, updates state, and emits related events
  */
 
 import { Order, OrderState, PaymentEvents } from '@rytass/payments';

--- a/packages/payments-adapter-newebpay-tcc/src/newebpay-order.ts
+++ b/packages/payments-adapter-newebpay-tcc/src/newebpay-order.ts
@@ -64,7 +64,7 @@ export class NewebPayOrder implements Order<NewebPayOrderCommitMessage> {
   infoRetrieved(info: AsyncOrderInformation<NewebPayOrderCommitMessage>): void {
     this.asyncInfo = info;
     this.state = OrderState.ASYNC_INFO_RETRIEVED;
-    this._gateway._emitter.emit(PaymentEvents.ORDER_INFO_RETRIEVED, this);
+    this._gateway.emitter.emit(PaymentEvents.ORDER_INFO_RETRIEVED, this);
   }
 
   fail(code: string, message: string): void {
@@ -136,7 +136,7 @@ export class NewebPayOrder implements Order<NewebPayOrderCommitMessage> {
           payTime: data.PayTime,
         };
 
-        this._gateway._emitter.emit(PaymentEvents.ORDER_COMMITTED, this);
+        this._gateway.emitter.emit(PaymentEvents.ORDER_COMMITTED, this);
       } else {
         this.state = OrderState.FAILED;
         result = {
@@ -144,7 +144,7 @@ export class NewebPayOrder implements Order<NewebPayOrderCommitMessage> {
           error: { code: data.Status, message: data.Message },
         };
 
-        this._gateway._emitter.emit(PaymentEvents.ORDER_FAILED, this);
+        this._gateway.emitter.emit(PaymentEvents.ORDER_FAILED, this);
       }
     } catch (err: any) {
       this.state = OrderState.FAILED;
@@ -153,7 +153,7 @@ export class NewebPayOrder implements Order<NewebPayOrderCommitMessage> {
         error: { code: 'DECODE_FAIL', message: err.message },
       };
 
-      this._gateway._emitter.emit(PaymentEvents.ORDER_FAILED, this);
+      this._gateway.emitter.emit(PaymentEvents.ORDER_FAILED, this);
     }
 
     return result;

--- a/packages/payments-adapter-newebpay-tcc/src/newebpay-payment.ts
+++ b/packages/payments-adapter-newebpay-tcc/src/newebpay-payment.ts
@@ -1,3 +1,32 @@
+/**
+ * NewebPayPayment (Gateway)
+ * --------------------------------------------------
+ * Entry point for NewebPay Tokenized Credit Card (TCC) integration.
+ *
+ * Provides a unified interface to handle:
+ *   - Initial card binding (P1 / NPA-B101)
+ *   - Subsequent token-based payments (Pn / NPA-B102)
+ *   - Token status query (NPA-B103)
+ *   - Token unbinding (NPA-B104)
+ *
+ * Core features:
+ *   - AES encryption + SHA-256 signature (CBC or GCM)
+ *   - Form generator for P1 HTML submission
+ *   - Callback handling for bind success/failure
+ *   - Event-driven architecture via EventEmitter
+ *
+ * Exposes methods:
+ *   - createBindCardRequest()
+ *   - handleBindCardCallback()
+ *   - createOrder()
+ *   - queryBindCard()
+ *   - unbindCard()
+ *
+ * Emits PaymentEvents such as:
+ *   - CARD_BOUND / CARD_BINDING_FAILED
+ *   - ORDER_COMMITTED / ORDER_FAILED
+ */
+
 import {
   InputFromOrderCommitMessage,
   Order,
@@ -86,8 +115,12 @@ export class NewebPayPayment
     return json;
   }
 
+  /* ------------------------------------------------------------------ */
+  /* P1 Bind Card Flow                                                  */
+  /* ------------------------------------------------------------------ */
+
   /**
-   * 建立 NewebPayBindCardRequest 物件，產生表單提交資料
+   * Create a NewebPayBindCardRequest instance to generate form submission data.
    */
   createBindCardRequest(
     payload: NewebPayBindCardRequestInput,
@@ -132,7 +165,7 @@ export class NewebPayPayment
   }
 
   /**
-   * 接收 NotifyURL 回傳資料（P1 callback），並觸發綁卡成功或失敗事件
+   * Handle data returned from the NotifyURL (P1 callback) and emit success or failure events for card binding.
    */
   handleBindCardCallback(tradeInfo: string, tradeSha: string): void {
     const raw = decodePayload(tradeInfo, tradeSha, this.encodeOpts);

--- a/packages/payments-adapter-newebpay-tcc/src/newebpay-payment.ts
+++ b/packages/payments-adapter-newebpay-tcc/src/newebpay-payment.ts
@@ -1,0 +1,220 @@
+import { PaymentEvents } from '@rytass/payments';
+import { EventEmitter } from 'node:events';
+import { NewebPayBindCardRequest } from './newebpay-bind-card-request';
+import { decodePayload, EncodeOptions, encodePayload } from './newebpay-crypto';
+import { NewebPayOrder } from './newebpay-order';
+import {
+  HttpResponse,
+  NewebPayBindCardRequestInput,
+  NewebPayBindCardRequestPayload,
+  NewebPayBindCardRequestState,
+  NewebPayBindCardResult,
+  NewebPayOrderInput,
+  NewebPayPaymentOptions,
+  QueryBindCardResult,
+  UnbindCardResult,
+} from './typings';
+
+export class NewebPayPayment {
+  readonly _emitter = new EventEmitter();
+
+  readonly merchantId: string;
+  readonly key: string;
+  readonly iv: string;
+  readonly encryptType: 0 | 1;
+  readonly baseUrl: string;
+
+  readonly _bindCardCache = new Map<string, NewebPayBindCardRequest>();
+
+  constructor(options: NewebPayPaymentOptions) {
+    this.merchantId = options.merchantId;
+    this.key = options.aesKey;
+    this.iv = options.aesIv;
+    this.encryptType = options.encryptType ?? 0;
+    this.baseUrl = options.baseUrl ?? 'https://ccore.newebpay.com';
+  }
+
+  createOrder(input: NewebPayOrderInput): NewebPayOrder {
+    return new NewebPayOrder(input, this);
+  }
+
+  /* ------------------------------------------------------------------ */
+  /* Common helpers                                                      */
+  /* ------------------------------------------------------------------ */
+
+  get encodeOpts(): EncodeOptions {
+    return { key: this.key, iv: this.iv, encryptType: this.encryptType };
+  }
+
+  private async postForm<T = any>(
+    path: string,
+    form: Record<string, string>,
+  ): Promise<HttpResponse<T>> {
+    const url = `${this.baseUrl}${path}`;
+
+    const body = new URLSearchParams();
+
+    Object.entries(form).forEach(([k, v]) => body.append(k, v));
+
+    const resp = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body,
+    });
+
+    if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+
+    const json = (await resp.json()) as HttpResponse<T>;
+
+    return json;
+  }
+
+  /**
+   * 建立 NewebPayBindCardRequest 物件，產生表單提交資料
+   */
+  createBindCardRequest(
+    payload: NewebPayBindCardRequestInput,
+  ): NewebPayBindCardRequest {
+    const normalized: NewebPayBindCardRequestPayload = {
+      MerchantID: this.merchantId,
+      RespondType: payload.RespondType ?? 'JSON',
+      Version: payload.Version ?? '2.1',
+      TimeStamp: payload.TimeStamp ?? Math.floor(Date.now() / 1000),
+      MerchantOrderNo: payload.MerchantOrderNo,
+      Amt: payload.Amt,
+      ItemDesc: payload.ItemDesc,
+      CREDITAGREEMENT: payload.CREDITAGREEMENT,
+      TokenTerm: payload.TokenTerm,
+      ...(payload.ReturnURL && { ReturnURL: payload.ReturnURL }),
+      ...(payload.NotifyURL && { NotifyURL: payload.NotifyURL }),
+      ...(payload.ClientBackURL && { ClientBackURL: payload.ClientBackURL }),
+      ...(payload.Email && { Email: payload.Email }),
+      ...(payload.EmailModify !== undefined && {
+        EmailModify: payload.EmailModify,
+      }),
+      ...(payload.TokenLife && { TokenLife: payload.TokenLife }),
+      ...(payload.UseFor !== undefined && { UseFor: payload.UseFor }),
+      ...(payload.MobileVerify !== undefined && {
+        MobileVerify: payload.MobileVerify,
+      }),
+      ...(payload.MobileNumber && { MobileNumber: payload.MobileNumber }),
+      ...(payload.MobileNumberModify !== undefined && {
+        MobileNumberModify: payload.MobileNumberModify,
+      }),
+    };
+
+    const request = new NewebPayBindCardRequest(
+      normalized,
+      this.encodeOpts,
+      this._emitter,
+    );
+
+    this._bindCardCache.set(normalized.TokenTerm, request);
+
+    return request;
+  }
+
+  /**
+   * 接收 NotifyURL 回傳資料（P1 callback），並觸發綁卡成功或失敗事件
+   */
+  handleBindCardCallback(tradeInfo: string, tradeSha: string): void {
+    const raw = decodePayload(tradeInfo, tradeSha, this.encodeOpts);
+
+    const status = raw['Status'];
+    const message = raw['Message'];
+    const tokenTerm = raw['TokenTerm'];
+
+    const result: NewebPayBindCardResult = {
+      TokenTerm: raw['TokenTerm'],
+      TokenValue: raw['TokenValue'],
+      MerchantOrderNo: raw['MerchantOrderNo'],
+      Card6No: raw['Card6No'],
+      Card4No: raw['Card4No'],
+      PayTime: raw['PayTime'],
+    };
+
+    const request = this._bindCardCache.get(tokenTerm);
+
+    if (
+      !request ||
+      request.state !== NewebPayBindCardRequestState.FORM_GENERATED
+    ) {
+      throw new Error('No bind-card request found for this TokenTerm');
+    }
+
+    if (status === 'SUCCESS') {
+      request.bound(result);
+    } else {
+      request.fail(status, message, result);
+    }
+  }
+
+  /* ------------------------------------------------------------------ */
+  /* NPA-B103 Query Token                                               */
+  /* ------------------------------------------------------------------ */
+
+  async queryBindCard(
+    tokenTerm: string,
+    tokenValue: string,
+  ): Promise<HttpResponse<QueryBindCardResult>> {
+    const payload = {
+      MerchantID: this.merchantId,
+      TimeStamp: Math.floor(Date.now() / 1000),
+      TokenTerm: tokenTerm,
+      TokenValue: tokenValue,
+    };
+
+    const { encrypted: EncryptData, hash: HashData } = encodePayload(
+      payload,
+      this.encodeOpts,
+    );
+
+    const res = await this.postForm('/API/TokenCard/query', {
+      UID_: this.merchantId,
+      EncryptData_: EncryptData,
+      HashData_: HashData,
+      Version_: '1.0',
+      RespondType_: 'JSON',
+    });
+
+    return res;
+  }
+
+  /* ------------------------------------------------------------------ */
+  /* NPA-B104 Unbind Token                                              */
+  /* ------------------------------------------------------------------ */
+
+  async unbindCard(
+    tokenTerm: string,
+    tokenValue: string,
+  ): Promise<HttpResponse<UnbindCardResult>> {
+    const payload = {
+      MerchantID: this.merchantId,
+      TimeStamp: Math.floor(Date.now() / 1000),
+      TokenTerm: tokenTerm,
+      TokenValue: tokenValue,
+    };
+
+    const { encrypted: EncryptData, hash: HashData } = encodePayload(
+      payload,
+      this.encodeOpts,
+    );
+
+    const res = await this.postForm('/API/TokenCard/unbinding', {
+      UID_: this.merchantId,
+      EncryptData_: EncryptData,
+      HashData_: HashData,
+      Version_: '1.0',
+      RespondType_: 'JSON',
+    });
+
+    if (res.Status === 'SUCCESS') {
+      this._emitter.emit(PaymentEvents.CARD_BINDING_FAILED, {
+        tokenTerm,
+        tokenValue,
+      });
+    }
+
+    return res;
+  }
+}

--- a/packages/payments-adapter-newebpay-tcc/src/newebpay-response.ts
+++ b/packages/payments-adapter-newebpay-tcc/src/newebpay-response.ts
@@ -1,37 +1,36 @@
 /**
- * NewebPay Response helpers
+ * NewebPay Response Helpers
  * --------------------------------------------------
- * 封裝所有 NPA-B101 / B102 / B103 / B104（以及 P1 前台回傳）
- * 的解密與雜湊驗證邏輯，統一暴露兩個函式：
+ * Encapsulates decryption and hash verification logic for responses from
+ * NPA-B101 / B102 / B103 / B104 and the P1 frontend callback.
  *
- * 1. decodeTradeInfo  –  處理 P1 (NPA-F011) 或 B101/B102 直接回傳的
- *    { TradeInfo, TradeSha } 欄位。
+ * Provides two unified utility functions:
  *
- * 2. decodeEncryptData – 處理 B101/B102/B103/B104 HTTP JSON 回傳包裝：
+ * 1. decodeTradeInfo – Handles direct response with fields:
+ *    { TradeInfo, TradeSha }, typically from P1 (NPA-F011) or B101/B102.
+ *
+ * 2. decodeEncryptData – Handles JSON-wrapped response from B101/B102/B103/B104:
  *    {
  *      Status,
  *      Message,
  *      Result: { EncryptData, HashData }
  *    }
  *
- * 兩者皆在通過 SHA-256 驗證後，解開 AES，並回傳物件 (Record<string,string>)。
+ * Both functions verify SHA-256 hash, decrypt the AES payload,
+ * and return a flat object (Record<string, string>).
  */
 
 import { EncodeOptions } from './newebpay-crypto';
 import { decodePayload } from './newebpay-crypto';
 import { HttpResponse } from './typings';
 
-/* ------------------------------------------------------------------ */
-/* Types */
-/* ------------------------------------------------------------------ */
-
-/** 任何帶有 EncryptData / HashData 的結果包裝 */
+//Any response object containing EncryptData and HashData fields
 interface EncryptedResult {
   EncryptData: string;
   HashData: string;
 }
 
-/** 任何帶有 TradeInfo / TradeSha 的結果包裝 */
+// Any response object containing TradeInfo and TradeSha fields
 interface TradeInfoEnvelope {
   TradeInfo: string;
   TradeSha: string;
@@ -42,7 +41,7 @@ interface TradeInfoEnvelope {
 /* ------------------------------------------------------------------ */
 
 /**
- * Decode P1 / B101 / B102 回傳的 TradeInfo & TradeSha
+ * Decode TradeInfo & TradeSha returned from P1 / B101 / B102
  */
 export function decodeTradeInfo(
   env: TradeInfoEnvelope,
@@ -52,9 +51,9 @@ export function decodeTradeInfo(
 }
 
 /**
- * Decode JSON 包裝層的 EncryptData & HashData
+ * Decode JSON-wrapped EncryptData & HashData from B101/B102/B103/B104
  *
- * @throws Error  若 SHA-256 驗證失敗或 HTTP Status != SUCCESS
+ * @throws Error if SHA-256 verification fails or HTTP Status !== 'SUCCESS'
  */
 export function decodeEncryptData<T extends EncryptedResult = EncryptedResult>(
   apiResp: HttpResponse<T>,

--- a/packages/payments-adapter-newebpay-tcc/src/newebpay-response.ts
+++ b/packages/payments-adapter-newebpay-tcc/src/newebpay-response.ts
@@ -1,0 +1,69 @@
+/**
+ * NewebPay Response helpers
+ * --------------------------------------------------
+ * 封裝所有 NPA-B101 / B102 / B103 / B104（以及 P1 前台回傳）
+ * 的解密與雜湊驗證邏輯，統一暴露兩個函式：
+ *
+ * 1. decodeTradeInfo  –  處理 P1 (NPA-F011) 或 B101/B102 直接回傳的
+ *    { TradeInfo, TradeSha } 欄位。
+ *
+ * 2. decodeEncryptData – 處理 B101/B102/B103/B104 HTTP JSON 回傳包裝：
+ *    {
+ *      Status,
+ *      Message,
+ *      Result: { EncryptData, HashData }
+ *    }
+ *
+ * 兩者皆在通過 SHA-256 驗證後，解開 AES，並回傳物件 (Record<string,string>)。
+ */
+
+import { EncodeOptions } from './newebpay-crypto';
+import { decodePayload } from './newebpay-crypto';
+import { HttpResponse } from './typings';
+
+/* ------------------------------------------------------------------ */
+/* Types */
+/* ------------------------------------------------------------------ */
+
+/** 任何帶有 EncryptData / HashData 的結果包裝 */
+interface EncryptedResult {
+  EncryptData: string;
+  HashData: string;
+}
+
+/** 任何帶有 TradeInfo / TradeSha 的結果包裝 */
+interface TradeInfoEnvelope {
+  TradeInfo: string;
+  TradeSha: string;
+}
+
+/* ------------------------------------------------------------------ */
+/* Core helpers */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Decode P1 / B101 / B102 回傳的 TradeInfo & TradeSha
+ */
+export function decodeTradeInfo(
+  env: TradeInfoEnvelope,
+  opts: EncodeOptions,
+): Record<string, string> {
+  return decodePayload(env.TradeInfo, env.TradeSha, opts);
+}
+
+/**
+ * Decode JSON 包裝層的 EncryptData & HashData
+ *
+ * @throws Error  若 SHA-256 驗證失敗或 HTTP Status != SUCCESS
+ */
+export function decodeEncryptData<T extends EncryptedResult = EncryptedResult>(
+  apiResp: HttpResponse<T>,
+  opts: EncodeOptions,
+): Record<string, string> {
+  if (apiResp.Status !== 'SUCCESS')
+    throw new Error(`NewebPay Status=${apiResp.Status} (${apiResp.Message})`);
+
+  const { EncryptData, HashData } = apiResp.Result;
+
+  return decodePayload(EncryptData, HashData, opts);
+}

--- a/packages/payments-adapter-newebpay-tcc/src/typings.ts
+++ b/packages/payments-adapter-newebpay-tcc/src/typings.ts
@@ -147,3 +147,9 @@ export interface NewebPayOrderCommitMessage extends OrderCommitMessage {
   tokenTerm: string;
   tokenValue: string;
 }
+
+export enum NewebPayOrderState {
+  INITED = 'INITED',
+  COMMITTED = 'COMMITTED',
+  FAILED = 'FAILED',
+}

--- a/packages/payments-adapter-newebpay-tcc/src/typings.ts
+++ b/packages/payments-adapter-newebpay-tcc/src/typings.ts
@@ -1,0 +1,149 @@
+import { OrderCommitMessage } from '@rytass/payments';
+
+export interface TradeInfoResult {
+  TradeInfo: string;
+  TradeSha: string;
+  EncryptType: 0 | 1;
+}
+export interface PostDataResult {
+  PostData_: { EncryptData: string; HashData: string };
+  EncryptType_: 0 | 1;
+}
+
+/** 綁卡請求狀態 */
+export enum NewebPayBindCardRequestState {
+  INITED = 'INITED',
+  FORM_GENERATED = 'FORM_GENERATED',
+  BOUND = 'BOUND',
+  FAILED = 'FAILED',
+}
+
+/** P1 前台幕前綁卡所需主要欄位 (部分選填欄位省略) */
+export interface NewebPayBindCardRequestPayload {
+  MerchantID: string;
+  RespondType: 'JSON' | 'String';
+  TimeStamp: number | string;
+  Version: '2.1';
+  MerchantOrderNo: string;
+  Amt: number;
+  ItemDesc: string;
+  CREDITAGREEMENT: 1; // 固定帶 1
+  TokenTerm: string;
+  // 可選欄位
+  ReturnURL?: string;
+  NotifyURL?: string;
+  ClientBackURL?: string;
+  Email?: string;
+  EmailModify?: 0 | 1;
+  TokenLife?: string;
+  UseFor?: 0 | 1 | 2;
+  MobileVerify?: 0 | 1 | 2;
+  MobileNumber?: string;
+  MobileNumberModify?: 0 | 1;
+  [key: string]: string | number | undefined;
+}
+
+export type NewebPayBindCardRequestInput = {
+  MerchantOrderNo: string;
+  Amt: number;
+  ItemDesc: string;
+  CREDITAGREEMENT: 1;
+  TokenTerm: string;
+  ReturnURL?: string;
+  NotifyURL?: string;
+  ClientBackURL?: string;
+  Email?: string;
+  EmailModify?: 0 | 1;
+  TokenLife?: string;
+  UseFor?: 0 | 1 | 2;
+  MobileVerify?: 0 | 1 | 2;
+  MobileNumber?: string;
+  MobileNumberModify?: 0 | 1;
+  RespondType?: 'JSON' | 'String';
+  Version?: '2.1';
+  TimeStamp?: number | string;
+};
+
+/** 綁卡 callback 主要欄位 (NPA-F011 回傳) */
+export interface NewebPayBindCardCallbackPayload {
+  Status: 'SUCCESS' | string;
+  MerchantID: string;
+  TradeInfo: string;
+  TradeSha: string;
+  Version: string;
+}
+
+/** 解析 TradeInfo 後的 Result 片段 (最常用欄位) */
+export interface NewebPayBindCardResult {
+  TokenTerm: string;
+  TokenValue: string;
+  MerchantOrderNo: string;
+  Card6No: string;
+  Card4No: string;
+  PayTime: string; // yyyy-MM-dd HH:mm:ss
+}
+
+export interface NewebPayPaymentOptions {
+  merchantId: string;         // 藍新配發之商店代碼
+  aesKey: string;             // 藍新配發之金鑰 (AES 使用)
+  aesIv: string;              // IV 向量，與金鑰配對
+  encryptType?: 0 | 1;        // 0 = AES/CBC (預設), 1 = AES/GCM
+  baseUrl?: string;           // API base URL，預設為 https://ccore.newebpay.com
+}
+
+export interface HttpResponse<T = any> {
+  Status: string;
+  Message: string;
+  Result: T;
+}
+
+/** NPA-B103 query result wrapper (EncryptData/HashData) */
+export interface QueryBindCardResult {
+  EncryptData: string;
+  HashData: string;
+}
+
+/** NPA-B104 unbind result wrapper (EncryptData/HashData) */
+export interface UnbindCardResult {
+  EncryptData: string;
+  HashData: string;
+}
+
+export interface NewebPayOrderInput {
+  MerchantOrderNo: string;    // 商店訂單編號
+  Amt: number;                // 交易金額
+  ItemDesc: string;           // 商品描述
+  Email?: string;             // 顧客 Email
+  TokenValue: string;         // 綁卡後取得的 TokenValue
+  TokenTerm: string;          // 商店傳入的綁卡識別值
+  P3D?: 0 | 1;                // 是否使用 3D 驗證
+  Stage?: number;             // 分期期數
+  RespondType?: 'JSON' | 'String';
+  TimeStamp?: number;
+  Version?: string;
+  [key: string]: any;
+}
+
+export interface NewebPayOrderCommitResult {
+  success: boolean;
+  tradeNo?: string;
+  payTime?: string;
+  error?: {
+    code: string;
+    message: string;
+  };
+}
+
+/** 回傳 EncryptData 解密後常用欄位 (最小子集) */
+export interface PnEncryptData {
+  MerchantOrderNo: string;
+  TradeNo: string;
+  PayTime: string; // yyyy-MM-dd HH:mm:ss
+  Status: string; // SUCCESS or code
+  Message: string;
+}
+
+export interface NewebPayOrderCommitMessage extends OrderCommitMessage {
+  tokenTerm: string;
+  tokenValue: string;
+}

--- a/packages/payments-adapter-newebpay-tcc/src/typings.ts
+++ b/packages/payments-adapter-newebpay-tcc/src/typings.ts
@@ -1,54 +1,61 @@
 import { OrderCommitMessage } from '@rytass/payments';
 
+/** TradeInfo + TradeSha（前台提交時使用） */
 export interface TradeInfoResult {
-  TradeInfo: string;
-  TradeSha: string;
-  EncryptType: 0 | 1;
+  TradeInfo: string; // AES 加密後的十六進位字串
+  TradeSha: string; // 對應 HashKey + TradeInfo + HashIV 雜湊值
+  EncryptType: 0 | 1; // 0=AES/CBC；1=AES/GCM
 }
+
+/** EncryptData + HashData（API 傳送時使用） */
 export interface PostDataResult {
-  PostData_: { EncryptData: string; HashData: string };
-  EncryptType_: 0 | 1;
+  PostData_: {
+    EncryptData: string; // AES 加密後十六進位字串
+    HashData: string; // SHA256 雜湊字串
+  };
+  EncryptType_: 0 | 1; // 0=CBC, 1=GCM
 }
 
 /** 綁卡請求狀態 */
 export enum NewebPayBindCardRequestState {
-  INITED = 'INITED',
-  FORM_GENERATED = 'FORM_GENERATED',
-  BOUND = 'BOUND',
-  FAILED = 'FAILED',
+  INITED = 'INITED', // 尚未產生表單
+  FORM_GENERATED = 'FORM_GENERATED', // 已產生表單，待送出
+  BOUND = 'BOUND', // 綁卡成功
+  FAILED = 'FAILED', // 綁卡失敗
 }
 
-/** P1 前台幕前綁卡所需主要欄位 (部分選填欄位省略) */
+/** P1 前台幕前綁卡所需主要欄位（依文件 NPA-F011） */
 export interface NewebPayBindCardRequestPayload {
-  MerchantID: string;
-  RespondType: 'JSON' | 'String';
-  TimeStamp: number | string;
-  Version: '2.1';
-  MerchantOrderNo: string;
-  Amt: number;
-  ItemDesc: string;
-  CREDITAGREEMENT: 1; // 固定帶 1
-  TokenTerm: string;
-  // 可選欄位
-  ReturnURL?: string;
-  NotifyURL?: string;
-  ClientBackURL?: string;
-  Email?: string;
-  EmailModify?: 0 | 1;
-  TokenLife?: string;
-  UseFor?: 0 | 1 | 2;
-  MobileVerify?: 0 | 1 | 2;
-  MobileNumber?: string;
-  MobileNumberModify?: 0 | 1;
-  [key: string]: string | number | undefined;
+  MerchantID: string; // 商店代碼（由藍新提供）
+  RespondType: 'JSON' | 'String'; // 回傳格式
+  TimeStamp: number | string; // 時間戳記（UNIX 秒）
+  Version: '2.1'; // API 版本
+  MerchantOrderNo: string; // 商店訂單編號
+  Amt: number; // 授權金額（最少為 1）
+  ItemDesc: string; // 商品描述
+  CREDITAGREEMENT: 1; // 固定傳 1，啟用約定交易
+  TokenTerm: string; // 商店綁卡識別值（自訂）
+  // 以下為選填欄位（依文件註明）
+  ReturnURL?: string; // 交易完成後跳轉頁（前台）
+  NotifyURL?: string; // 綁卡完成後伺服器通知 URL
+  ClientBackURL?: string; // 用戶取消時返回頁面
+  Email?: string; // 使用者 Email
+  EmailModify?: 0 | 1; // 是否允許修改 Email
+  TokenLife?: string; // Token 有效天數（預設永久）
+  UseFor?: 0 | 1 | 2; // 綁卡用途：0=不限, 1=定期, 2=非定期
+  MobileVerify?: 0 | 1 | 2; // 手機驗證選項
+  MobileNumber?: string; // 手機號碼（限台灣門號）
+  MobileNumberModify?: 0 | 1; // 是否允許修改手機
+  [key: string]: string | number | undefined; // 保留彈性欄位
 }
 
+/** 前台綁卡請求輸入（可缺省部分欄位） */
 export type NewebPayBindCardRequestInput = {
-  MerchantOrderNo: string;
-  Amt: number;
-  ItemDesc: string;
-  CREDITAGREEMENT: 1;
-  TokenTerm: string;
+  MerchantOrderNo: string; // 訂單編號
+  Amt: number; // 金額
+  ItemDesc: string; // 描述
+  CREDITAGREEMENT: 1; // 固定傳 1
+  TokenTerm: string; // 綁卡識別碼
   ReturnURL?: string;
   NotifyURL?: string;
   ClientBackURL?: string;
@@ -64,90 +71,96 @@ export type NewebPayBindCardRequestInput = {
   TimeStamp?: number | string;
 };
 
-/** 綁卡 callback 主要欄位 (NPA-F011 回傳) */
+/** P1 綁卡完成後（NotifyURL 回傳）的 callback 主體欄位 */
 export interface NewebPayBindCardCallbackPayload {
-  Status: 'SUCCESS' | string;
-  MerchantID: string;
-  TradeInfo: string;
-  TradeSha: string;
-  Version: string;
+  Status: 'SUCCESS' | string; // 綁卡狀態
+  MerchantID: string; // 商店代碼
+  TradeInfo: string; // AES 加密後資料
+  TradeSha: string; // SHA256 雜湊值
+  Version: string; // API 版本
 }
 
-/** 解析 TradeInfo 後的 Result 片段 (最常用欄位) */
+/** 解析 TradeInfo 解開後的常用欄位（綁卡成功回傳） */
 export interface NewebPayBindCardResult {
-  TokenTerm: string;
-  TokenValue: string;
-  MerchantOrderNo: string;
-  Card6No: string;
-  Card4No: string;
-  PayTime: string; // yyyy-MM-dd HH:mm:ss
+  TokenTerm: string; // 商店自訂綁卡識別碼
+  TokenValue: string; // 綁卡成功後回傳的 Token
+  MerchantOrderNo: string; // 原始訂單編號
+  Card6No: string; // 卡號前六碼
+  Card4No: string; // 卡號後四碼
+  PayTime: string; // 綁卡完成時間 yyyy-MM-dd HH:mm:ss
 }
 
+/** Gateway 初始化參數 */
 export interface NewebPayPaymentOptions {
-  merchantId: string;         // 藍新配發之商店代碼
-  aesKey: string;             // 藍新配發之金鑰 (AES 使用)
-  aesIv: string;              // IV 向量，與金鑰配對
-  encryptType?: 0 | 1;        // 0 = AES/CBC (預設), 1 = AES/GCM
-  baseUrl?: string;           // API base URL，預設為 https://ccore.newebpay.com
+  merchantId: string; // 商店代碼（由藍新提供）
+  aesKey: string; // 加解密使用金鑰
+  aesIv: string; // 加解密使用 IV
+  encryptType?: 0 | 1; // 0=AES/CBC (預設), 1=AES/GCM
+  baseUrl?: string; // API base URL（預設 https://ccore.newebpay.com）
 }
 
+/** 所有 NewebPay API 通用的 Response 包裝格式 */
 export interface HttpResponse<T = any> {
-  Status: string;
-  Message: string;
-  Result: T;
+  Status: string; // 狀態：SUCCESS 或錯誤代碼
+  Message: string; // 錯誤訊息或成功描述
+  Result: T; // 內部加密資料或物件
 }
 
-/** NPA-B103 query result wrapper (EncryptData/HashData) */
+/** NPA-B103 查詢綁卡狀態回傳結果 */
 export interface QueryBindCardResult {
-  EncryptData: string;
-  HashData: string;
+  EncryptData: string; // 加密資料
+  HashData: string; // 雜湊驗證值
 }
 
-/** NPA-B104 unbind result wrapper (EncryptData/HashData) */
+/** NPA-B104 解綁回傳結果 */
 export interface UnbindCardResult {
   EncryptData: string;
   HashData: string;
 }
 
+/** 後續約定付款（NPA-B102）請求輸入 */
 export interface NewebPayOrderInput {
-  MerchantOrderNo: string;    // 商店訂單編號
-  Amt: number;                // 交易金額
-  ItemDesc: string;           // 商品描述
-  Email?: string;             // 顧客 Email
-  TokenValue: string;         // 綁卡後取得的 TokenValue
-  TokenTerm: string;          // 商店傳入的綁卡識別值
-  P3D?: 0 | 1;                // 是否使用 3D 驗證
-  Stage?: number;             // 分期期數
+  MerchantOrderNo: string; // 訂單編號
+  Amt: number; // 金額
+  ItemDesc: string; // 描述
+  Email?: string; // 顧客 Email
+  TokenValue: string; // 綁卡後取得的 TokenValue
+  TokenTerm: string; // 商店自定的 TokenTerm
+  P3D?: 0 | 1; // 是否使用 3D 驗證（0=否）
+  Stage?: number; // 分期期數（若使用）
   RespondType?: 'JSON' | 'String';
-  TimeStamp?: number;
-  Version?: string;
-  [key: string]: any;
+  TimeStamp?: number; // 時間戳記（UNIX 秒）
+  Version?: string; // API 版本
+  [key: string]: any; // 其他欄位
 }
 
+/** 後續付款回傳結果封裝 */
 export interface NewebPayOrderCommitResult {
-  success: boolean;
-  tradeNo?: string;
-  payTime?: string;
+  success: boolean; // 是否成功
+  tradeNo?: string; // 藍新交易編號
+  payTime?: string; // 扣款完成時間
   error?: {
-    code: string;
-    message: string;
+    code: string; // 錯誤代碼
+    message: string; // 錯誤說明
   };
 }
 
-/** 回傳 EncryptData 解密後常用欄位 (最小子集) */
+/** 解開 EncryptData 之後常見欄位集合 */
 export interface PnEncryptData {
-  MerchantOrderNo: string;
-  TradeNo: string;
-  PayTime: string; // yyyy-MM-dd HH:mm:ss
-  Status: string; // SUCCESS or code
-  Message: string;
+  MerchantOrderNo: string; // 訂單編號
+  TradeNo: string; // 藍新交易編號
+  PayTime: string; // 扣款時間 yyyy-MM-dd HH:mm:ss
+  Status: string; // SUCCESS 或錯誤代碼
+  Message: string; // 說明文字
 }
 
+/** Commit 後封裝的訊息（for Adapter event） */
 export interface NewebPayOrderCommitMessage extends OrderCommitMessage {
-  tokenTerm: string;
-  tokenValue: string;
+  tokenTerm: string; // 商店傳入綁卡識別值
+  tokenValue: string; // 藍新回傳之 Token 值
 }
 
+/** NewebPayOrder 狀態列舉 */
 export enum NewebPayOrderState {
   INITED = 'INITED',
   COMMITTED = 'COMMITTED',

--- a/packages/payments-adapter-newebpay-tcc/tsconfig.build.json
+++ b/packages/payments-adapter-newebpay-tcc/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./lib",
+    "declaration": true
+  },
+  "exclude": ["**/*.spec.*"],
+  "include": ["./src"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5879,6 +5879,22 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@rytass/payments-adapter-newebpay-tcc@workspace:packages/payments-adapter-newebpay-tcc":
+  version: 0.0.0-use.local
+  resolution: "@rytass/payments-adapter-newebpay-tcc@workspace:packages/payments-adapter-newebpay-tcc"
+  dependencies:
+    "@rytass/payments": "npm:^0.1.6"
+    "@types/debug": "npm:^4.1.12"
+    "@types/lru-cache": "npm:^7.10.10"
+    "@types/luxon": "npm:^3.4.2"
+    axios: "npm:^1.7.8"
+    debug: "npm:^4.3.7"
+    lru-cache: "npm:^11.0.2"
+    luxon: "npm:^3.5.0"
+    ngrok: "npm:^4.3.3"
+  languageName: unknown
+  linkType: soft
+
 "@rytass/payments-adapter-newebpay@workspace:packages/payments-adapter-newebpay":
   version: 0.0.0-use.local
   resolution: "@rytass/payments-adapter-newebpay@workspace:packages/payments-adapter-newebpay"


### PR DESCRIPTION
- Implement NewebPayPayment gateway for tokenized credit card flow
- Support P1 bind card flow with auto-submit form and callback handler
- Support Pn recurring payment via token with AES encryption and SHA256 verification
- Implement unified crypto helpers for TradeInfo, PostData, and hash generation
- Support B103 query and B104 unbind API with response decoding
- Emit standard PaymentEvents such as CARD_BOUND and ORDER_COMMITTED
- Provide NewebPayBindCardRequest and NewebPayOrder abstractions for Rytass adapter interface
- Add typings for bind card payloads, token result, and commit response
- Add usage documentation and README