### PR TITLE
refactor: align cms base module type definitions

### DIFF
--- a/packages/cms-base-nestjs-module/src/typings/cms-base-root-module-async-options.dto.ts
+++ b/packages/cms-base-nestjs-module/src/typings/cms-base-root-module-async-options.dto.ts
@@ -1,11 +1,62 @@
-import { InjectionToken, ModuleMetadata, OptionalFactoryDependency, Type } from '@nestjs/common';
-import { CMSBaseModuleOptionsDto } from './cms-base-root-module-options.dto';
-import { CMSBaseModuleOptionFactory } from './cms-base-root-module-option-factory';
+import type { ModuleMetadata, OptionalFactoryDependency, Type } from '@nestjs/common';
+import type { BaseArticleEntity } from '../models/base-article.entity';
+import type { BaseArticleVersionEntity } from '../models/base-article-version.entity';
+import type { BaseArticleVersionContentEntity } from '../models/base-article-version-content.entity';
+import type { BaseCategoryEntity } from '../models/base-category.entity';
+import type { BaseCategoryMultiLanguageNameEntity } from '../models/base-category-multi-language-name.entity';
+import type { BaseSignatureLevelEntity } from '../models/base-signature-level.entity';
+import type { CMSBaseModuleOptionsDto } from './cms-base-root-module-options.dto';
+import type { CMSBaseModuleOptionFactory } from './cms-base-root-module-option-factory';
+import type { DependencyInjectionToken, FactoryFunctionArgs } from './module-factory.type';
 
-export interface CMSBaseModuleAsyncOptionsDto extends Pick<ModuleMetadata, 'imports'> {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  useFactory?: (...args: any[]) => Promise<CMSBaseModuleOptionsDto> | CMSBaseModuleOptionsDto;
-  inject?: (InjectionToken | OptionalFactoryDependency)[];
-  useClass?: Type<CMSBaseModuleOptionFactory>;
-  useExisting?: Type<CMSBaseModuleOptionFactory>;
+export interface CMSBaseModuleAsyncOptionsDto<
+  ArticleEntity extends BaseArticleEntity = BaseArticleEntity,
+  ArticleVersionEntity extends BaseArticleVersionEntity = BaseArticleVersionEntity,
+  ArticleVersionContentEntity extends BaseArticleVersionContentEntity = BaseArticleVersionContentEntity,
+  CategoryEntity extends BaseCategoryEntity = BaseCategoryEntity,
+  CategoryMultiLanguageNameEntity extends BaseCategoryMultiLanguageNameEntity = BaseCategoryMultiLanguageNameEntity,
+  SignatureLevelEntity extends BaseSignatureLevelEntity = BaseSignatureLevelEntity,
+> extends Pick<ModuleMetadata, 'imports'> {
+  useFactory?: (
+    ...args: FactoryFunctionArgs
+  ) =>
+    | Promise<
+        CMSBaseModuleOptionsDto<
+          ArticleEntity,
+          ArticleVersionEntity,
+          ArticleVersionContentEntity,
+          CategoryEntity,
+          CategoryMultiLanguageNameEntity,
+          SignatureLevelEntity
+        >
+      >
+    | CMSBaseModuleOptionsDto<
+        ArticleEntity,
+        ArticleVersionEntity,
+        ArticleVersionContentEntity,
+        CategoryEntity,
+        CategoryMultiLanguageNameEntity,
+        SignatureLevelEntity
+      >;
+  inject?: readonly (DependencyInjectionToken | OptionalFactoryDependency)[];
+  useClass?: Type<
+    CMSBaseModuleOptionFactory<
+      ArticleEntity,
+      ArticleVersionEntity,
+      ArticleVersionContentEntity,
+      CategoryEntity,
+      CategoryMultiLanguageNameEntity,
+      SignatureLevelEntity
+    >
+  >;
+  useExisting?: Type<
+    CMSBaseModuleOptionFactory<
+      ArticleEntity,
+      ArticleVersionEntity,
+      ArticleVersionContentEntity,
+      CategoryEntity,
+      CategoryMultiLanguageNameEntity,
+      SignatureLevelEntity
+    >
+  >;
 }

--- a/packages/cms-base-nestjs-module/src/typings/cms-base-root-module-option-factory.ts
+++ b/packages/cms-base-nestjs-module/src/typings/cms-base-root-module-option-factory.ts
@@ -1,5 +1,36 @@
-import { CMSBaseModuleOptionsDto } from './cms-base-root-module-options.dto';
+import type { BaseArticleEntity } from '../models/base-article.entity';
+import type { BaseArticleVersionEntity } from '../models/base-article-version.entity';
+import type { BaseArticleVersionContentEntity } from '../models/base-article-version-content.entity';
+import type { BaseCategoryEntity } from '../models/base-category.entity';
+import type { BaseCategoryMultiLanguageNameEntity } from '../models/base-category-multi-language-name.entity';
+import type { BaseSignatureLevelEntity } from '../models/base-signature-level.entity';
+import type { CMSBaseModuleOptionsDto } from './cms-base-root-module-options.dto';
 
-export interface CMSBaseModuleOptionFactory {
-  createCMSOptions(): Promise<CMSBaseModuleOptionsDto> | CMSBaseModuleOptionsDto;
+export interface CMSBaseModuleOptionFactory<
+  ArticleEntity extends BaseArticleEntity = BaseArticleEntity,
+  ArticleVersionEntity extends BaseArticleVersionEntity = BaseArticleVersionEntity,
+  ArticleVersionContentEntity extends BaseArticleVersionContentEntity = BaseArticleVersionContentEntity,
+  CategoryEntity extends BaseCategoryEntity = BaseCategoryEntity,
+  CategoryMultiLanguageNameEntity extends BaseCategoryMultiLanguageNameEntity = BaseCategoryMultiLanguageNameEntity,
+  SignatureLevelEntity extends BaseSignatureLevelEntity = BaseSignatureLevelEntity,
+> {
+  createCMSOptions():
+    | Promise<
+        CMSBaseModuleOptionsDto<
+          ArticleEntity,
+          ArticleVersionEntity,
+          ArticleVersionContentEntity,
+          CategoryEntity,
+          CategoryMultiLanguageNameEntity,
+          SignatureLevelEntity
+        >
+      >
+    | CMSBaseModuleOptionsDto<
+        ArticleEntity,
+        ArticleVersionEntity,
+        ArticleVersionContentEntity,
+        CategoryEntity,
+        CategoryMultiLanguageNameEntity,
+        SignatureLevelEntity
+      >;
 }

--- a/packages/cms-base-nestjs-module/src/typings/cms-base-root-module-options.dto.ts
+++ b/packages/cms-base-nestjs-module/src/typings/cms-base-root-module-options.dto.ts
@@ -1,22 +1,29 @@
-import { BaseArticleVersionContentEntity } from '../models/base-article-version-content.entity';
-import { BaseArticleVersionEntity } from '../models/base-article-version.entity';
-import { BaseArticleEntity } from '../models/base-article.entity';
-import { BaseCategoryMultiLanguageNameEntity } from '../models/base-category-multi-language-name.entity';
-import { BaseCategoryEntity } from '../models/base-category.entity';
-import { BaseSignatureLevelEntity } from '../models/base-signature-level.entity';
+import type { BaseArticleVersionContentEntity } from '../models/base-article-version-content.entity';
+import type { BaseArticleVersionEntity } from '../models/base-article-version.entity';
+import type { BaseArticleEntity } from '../models/base-article.entity';
+import type { BaseCategoryMultiLanguageNameEntity } from '../models/base-category-multi-language-name.entity';
+import type { BaseCategoryEntity } from '../models/base-category.entity';
+import type { BaseSignatureLevelEntity } from '../models/base-signature-level.entity';
 
-export interface CMSBaseModuleOptionsDto {
+export interface CMSBaseModuleOptionsDto<
+  ArticleEntity extends BaseArticleEntity = BaseArticleEntity,
+  ArticleVersionEntity extends BaseArticleVersionEntity = BaseArticleVersionEntity,
+  ArticleVersionContentEntity extends BaseArticleVersionContentEntity = BaseArticleVersionContentEntity,
+  CategoryEntity extends BaseCategoryEntity = BaseCategoryEntity,
+  CategoryMultiLanguageNameEntity extends BaseCategoryMultiLanguageNameEntity = BaseCategoryMultiLanguageNameEntity,
+  SignatureLevelEntity extends BaseSignatureLevelEntity = BaseSignatureLevelEntity,
+> {
   multipleLanguageMode?: boolean; // default: false
   allowMultipleParentCategories?: boolean; // default: false
   allowCircularCategories?: boolean; // default: false
   fullTextSearchMode?: boolean; // default: false
-  signatureLevels?: string[] | BaseSignatureLevelEntity[];
+  signatureLevels?: string[] | SignatureLevelEntity[];
   enableDraftMode?: boolean; // default: false
   autoReleaseWhenLatestSignatureApproved?: boolean; // default: false
-  articleEntity?: new () => BaseArticleEntity;
-  articleVersionEntity?: new () => BaseArticleVersionEntity;
-  articleVersionContentEntity?: new () => BaseArticleVersionContentEntity;
-  categoryEntity?: new () => BaseCategoryEntity;
-  categoryMultiLanguageNameEntity?: new () => BaseCategoryMultiLanguageNameEntity;
-  signatureLevelEntity?: new () => BaseSignatureLevelEntity;
+  articleEntity?: new () => ArticleEntity;
+  articleVersionEntity?: new () => ArticleVersionEntity;
+  articleVersionContentEntity?: new () => ArticleVersionContentEntity;
+  categoryEntity?: new () => CategoryEntity;
+  categoryMultiLanguageNameEntity?: new () => CategoryMultiLanguageNameEntity;
+  signatureLevelEntity?: new () => SignatureLevelEntity;
 }

--- a/packages/cms-base-nestjs-module/src/typings/module-factory.type.ts
+++ b/packages/cms-base-nestjs-module/src/typings/module-factory.type.ts
@@ -1,4 +1,4 @@
-import { InjectionToken } from '@nestjs/common';
+import type { InjectionToken } from '@nestjs/common';
 
 /**
  * Represents possible dependency injection tokens


### PR DESCRIPTION
## Summary
- introduce generics for CMS base module option, async option, and option factory typings to mirror member module patterns
- adopt type-only imports and shared factory argument tokens to improve ESM friendliness for consumers

## Testing
- yarn eslint packages/cms-base-nestjs-module/src/typings --ext .ts

------
https://chatgpt.com/codex/tasks/task_e_68cf8648297c832193ec69b98136a181