### PR TITLE
feat(payments-adapter-newebpay): support partial refund amount

### DIFF
--- a/packages/payments-adapter-newebpay/__tests__/payments-adapter-newebpay.spec.ts
+++ b/packages/payments-adapter-newebpay/__tests__/payments-adapter-newebpay.spec.ts
@@ -8,7 +8,7 @@ process.env.NGROK_AUTHTOKEN = 'test-auth-token';
 
 import axios from 'axios';
 import http, { createServer } from 'http';
-import { OrderState } from '@rytass/payments';
+import { Channel, CreditCardECI, OrderState } from '@rytass/payments';
 import { createHash, createDecipheriv, randomBytes } from 'crypto';
 import {
   NewebPayCreditCardBalanceStatus,
@@ -647,6 +647,107 @@ describe('NewebPay Payments', () => {
       );
 
       expect((order.additionalInfo as NewebPayAdditionInfoCreditCard).remainingBalance).toBe(0);
+      expect(mockPost).toHaveBeenCalledTimes(1);
+    });
+
+    it('should keep cached bonus amount restriction after querying credit card order', async () => {
+      let cachedOrder: NewebPayOrder<NewebPayCreditCardCommitMessage> | undefined;
+      const paymentWithCache = new NewebPayPayment<NewebPayCreditCardCommitMessage>({
+        merchantId: MERCHANT_ID,
+        aesKey: AES_KEY,
+        aesIv: AES_IV,
+        ordersCache: {
+          get: async (): Promise<NewebPayOrder<NewebPayCreditCardCommitMessage> | undefined> => cachedOrder,
+          set: async (_key: string, value: NewebPayOrder<NewebPayCreditCardCommitMessage>): Promise<void> => {
+            cachedOrder = value;
+          },
+        },
+      });
+
+      cachedOrder = new NewebPayOrder<NewebPayCreditCardCommitMessage>(
+        {
+          id: 'bonus-query-order',
+          channel: NewebPaymentChannel.CREDIT,
+          items: [{ name: 'Test', quantity: 1, unitPrice: 200 }],
+          gateway: paymentWithCache,
+          platformTradeNumber: 'MS197067234',
+          createdAt: new Date(),
+          committedAt: new Date(),
+          status: NewebPayOrderStatusFromAPI.COMMITTED,
+        },
+        {
+          channel: Channel.CREDIT_CARD,
+          processDate: new Date(),
+          authCode: '123456',
+          amount: 200,
+          eci: CreditCardECI.MASTER_3D,
+          card4Number: '8888',
+          card6Number: '000000',
+          authBank: 'KGI',
+          subChannel: 'CREDIT',
+          bonusAmount: 60,
+          closeBalance: 200,
+          closeStatus: NewebPayCreditCardBalanceStatus.SETTLED,
+          remainingBalance: 200,
+          refundStatus: NewebPayCreditCardBalanceStatus.UNSETTLED,
+        } as NewebPayAdditionInfoCreditCard,
+      );
+
+      mockPost.mockImplementationOnce(async (url: string, data: string) => {
+        expect(url).toMatch(/\/API\/QueryTradeInfo/);
+
+        const payload = new URLSearchParams(data);
+        const amt = payload.get('Amt');
+        const merchantId = payload.get('MerchantID');
+        const merchantOrderNo = payload.get('MerchantOrderNo');
+
+        return {
+          data: {
+            Status: 'SUCCESS',
+            Message: '',
+            Result: {
+              MerchantID: merchantId,
+              Amt: amt,
+              TradeNo: 'MS197067234',
+              MerchantOrderNo: merchantOrderNo,
+              TradeStatus: NewebPayOrderStatusFromAPI.COMMITTED,
+              PaymentType: 'CREDIT',
+              CreateTime: '2023-02-01 21:54:47',
+              PayTime: '2023-02-01 21:54:58',
+              CheckCode: createHash('sha256')
+                .update(
+                  `HashIV=${AES_IV}&Amt=${amt}&MerchantID=${MERCHANT_ID}&MerchantOrderNo=${merchantOrderNo}&TradeNo=MS197067234&HashKey=${AES_KEY}`,
+                )
+                .digest('hex')
+                .toUpperCase(),
+              FundTime: '2023-02-25',
+              RespondCode: '00',
+              Auth: '123456',
+              ECI: '2',
+              CloseAmt: amt,
+              CloseStatus: NewebPayCreditCardBalanceStatus.SETTLED,
+              BackBalance: '200',
+              BackStatus: NewebPayCreditCardBalanceStatus.UNSETTLED,
+              RespondMsg: '',
+              Inst: '',
+              InstFirst: '',
+              InstEach: '',
+              PaymentMethod: 'CREDIT',
+              Card6No: '000000',
+              Card4No: '8888',
+              AuthBank: 'KGI',
+            },
+          },
+        };
+      });
+
+      const order = await paymentWithCache.query<NewebPayOrder<NewebPayCreditCardCommitMessage>>(
+        'bonus-query-order',
+        200,
+      );
+
+      expect((order.additionalInfo as NewebPayAdditionInfoCreditCard).bonusAmount).toBe(60);
+      await expect(order.refund(40)).rejects.toThrow('Partial refund not supported for bonus-discount payments');
       expect(mockPost).toHaveBeenCalledTimes(1);
     });
 

--- a/packages/payments-adapter-newebpay/__tests__/refund.spec.ts
+++ b/packages/payments-adapter-newebpay/__tests__/refund.spec.ts
@@ -602,7 +602,7 @@ describe('NewebPay Refund Order', () => {
       } as NewebPayAdditionInfoCreditCard,
     );
 
-    expect(() => order.cancelRefund()).rejects.toThrow('Refund order failed');
+    await expect(order.cancelRefund()).rejects.toThrow('Refund order failed');
   });
 
   it('should throw error on cancel refund a not settled order', () => {

--- a/packages/payments-adapter-newebpay/__tests__/refund.spec.ts
+++ b/packages/payments-adapter-newebpay/__tests__/refund.spec.ts
@@ -1648,4 +1648,85 @@ describe('NewebPay Refund Order', () => {
     expect(order.state).toBe(OrderState.REFUNDED);
     expect(sentAmts).toEqual(['20', '20/cancel']);
   });
+
+  it('should reject explicit cancelRefund amount greater than current pending refund amount', async () => {
+    const mockedPost = jest.spyOn(axios, 'post');
+
+    const sentAmts: string[] = [];
+
+    mockedPost.mockImplementation(async (_url: string, data: string) => {
+      const payload = new URLSearchParams(data);
+      const postData = payload.get('PostData_');
+      const decipher = createDecipheriv('aes-256-cbc', AES_KEY, AES_IV);
+
+      const plainInfo = `${decipher.update(postData!, 'hex', 'utf8')}${decipher.final('utf8')}`;
+      const requestBody = new URLSearchParams(plainInfo);
+
+      sentAmts.push(`${requestBody.get('Amt')}${requestBody.get('Cancel') ? '/cancel' : ''}`);
+
+      return {
+        data: {
+          Status: 'SUCCESS',
+          Message: '',
+          Result: {
+            CheckCode: createHash('sha256')
+              .update(`HashKey=${AES_KEY}&${postData}&HashIV=${AES_IV}`)
+              .digest('hex')
+              .toUpperCase(),
+          },
+        },
+      };
+    });
+
+    const order = new NewebPayOrder<NewebPayCreditCardCommitMessage>(
+      {
+        id: 'explicit-cancel-over-pending',
+        channel: NewebPaymentChannel.CREDIT,
+        items: [{ name: 'Test', quantity: 1, unitPrice: 100 }],
+        gateway: payment,
+        platformTradeNumber: '12937917203',
+        createdAt: new Date(),
+        committedAt: new Date(),
+        status: NewebPayOrderStatusFromAPI.REFUNDED,
+      },
+      {
+        channel: Channel.CREDIT_CARD,
+        processDate: new Date(),
+        authCode: '123123',
+        amount: 100,
+        eci: CreditCardECI.MASTER_3D,
+        card4Number: '9234',
+        card6Number: '124902',
+        authBank: 'Taishin',
+        subChannel: 'CREDIT',
+        speedCheckoutMode: NewebPayCreditCardSpeedCheckoutMode.NONE,
+        bonusAmount: 0,
+        closeBalance: 100,
+        closeStatus: NewebPayCreditCardBalanceStatus.SETTLED,
+        remainingBalance: 60,
+        refundStatus: NewebPayCreditCardBalanceStatus.SETTLED,
+      } as NewebPayAdditionInfoCreditCard,
+    );
+
+    await order.refund(20);
+
+    await expect(order.cancelRefund(30)).rejects.toThrow('Cancel refund amount cannot exceed refunded amount');
+
+    expect((order.additionalInfo as NewebPayAdditionInfoCreditCard).remainingBalance).toBe(40);
+    expect((order.additionalInfo as NewebPayAdditionInfoCreditCard).refundStatus).toBe(
+      NewebPayCreditCardBalanceStatus.WAITING,
+    );
+
+    expect(order.state).toBe(OrderState.REFUNDED);
+
+    await order.cancelRefund(20);
+
+    expect((order.additionalInfo as NewebPayAdditionInfoCreditCard).remainingBalance).toBe(60);
+    expect((order.additionalInfo as NewebPayAdditionInfoCreditCard).refundStatus).toBe(
+      NewebPayCreditCardBalanceStatus.SETTLED,
+    );
+
+    expect(order.state).toBe(OrderState.REFUNDED);
+    expect(sentAmts).toEqual(['20', '20/cancel']);
+  });
 });

--- a/packages/payments-adapter-newebpay/__tests__/refund.spec.ts
+++ b/packages/payments-adapter-newebpay/__tests__/refund.spec.ts
@@ -1572,4 +1572,80 @@ describe('NewebPay Refund Order', () => {
 
     expect(sentAmts).toEqual(['40', '40/cancel', '100']);
   });
+
+  it('should default cancelRefund() to the current pending refund amount after prior settled partial refund', async () => {
+    const mockedPost = jest.spyOn(axios, 'post');
+
+    const sentAmts: string[] = [];
+
+    mockedPost.mockImplementation(async (_url: string, data: string) => {
+      const payload = new URLSearchParams(data);
+      const postData = payload.get('PostData_');
+      const decipher = createDecipheriv('aes-256-cbc', AES_KEY, AES_IV);
+
+      const plainInfo = `${decipher.update(postData!, 'hex', 'utf8')}${decipher.final('utf8')}`;
+      const requestBody = new URLSearchParams(plainInfo);
+
+      sentAmts.push(`${requestBody.get('Amt')}${requestBody.get('Cancel') ? '/cancel' : ''}`);
+
+      return {
+        data: {
+          Status: 'SUCCESS',
+          Message: '',
+          Result: {
+            CheckCode: createHash('sha256')
+              .update(`HashKey=${AES_KEY}&${postData}&HashIV=${AES_IV}`)
+              .digest('hex')
+              .toUpperCase(),
+          },
+        },
+      };
+    });
+
+    const order = new NewebPayOrder<NewebPayCreditCardCommitMessage>(
+      {
+        id: 'prior-settled-then-pending',
+        channel: NewebPaymentChannel.CREDIT,
+        items: [{ name: 'Test', quantity: 1, unitPrice: 100 }],
+        gateway: payment,
+        platformTradeNumber: '12937917203',
+        createdAt: new Date(),
+        committedAt: new Date(),
+        status: NewebPayOrderStatusFromAPI.REFUNDED,
+      },
+      {
+        channel: Channel.CREDIT_CARD,
+        processDate: new Date(),
+        authCode: '123123',
+        amount: 100,
+        eci: CreditCardECI.MASTER_3D,
+        card4Number: '9234',
+        card6Number: '124902',
+        authBank: 'Taishin',
+        subChannel: 'CREDIT',
+        speedCheckoutMode: NewebPayCreditCardSpeedCheckoutMode.NONE,
+        bonusAmount: 0,
+        closeBalance: 100,
+        closeStatus: NewebPayCreditCardBalanceStatus.SETTLED,
+        remainingBalance: 60,
+        refundStatus: NewebPayCreditCardBalanceStatus.SETTLED,
+      } as NewebPayAdditionInfoCreditCard,
+    );
+
+    await order.refund(20);
+    expect((order.additionalInfo as NewebPayAdditionInfoCreditCard).remainingBalance).toBe(40);
+    expect((order.additionalInfo as NewebPayAdditionInfoCreditCard).refundStatus).toBe(
+      NewebPayCreditCardBalanceStatus.WAITING,
+    );
+
+    await order.cancelRefund();
+
+    expect((order.additionalInfo as NewebPayAdditionInfoCreditCard).remainingBalance).toBe(60);
+    expect((order.additionalInfo as NewebPayAdditionInfoCreditCard).refundStatus).toBe(
+      NewebPayCreditCardBalanceStatus.SETTLED,
+    );
+
+    expect(order.state).toBe(OrderState.REFUNDED);
+    expect(sentAmts).toEqual(['20', '20/cancel']);
+  });
 });

--- a/packages/payments-adapter-newebpay/__tests__/refund.spec.ts
+++ b/packages/payments-adapter-newebpay/__tests__/refund.spec.ts
@@ -104,7 +104,7 @@ describe('NewebPay Refund Order', () => {
         bonusAmount: 0,
         closeBalance: 100,
         closeStatus: NewebPayCreditCardBalanceStatus.SETTLED,
-        remainingBalance: 0,
+        remainingBalance: 100,
         refundStatus: NewebPayCreditCardBalanceStatus.UNSETTLED,
       } as NewebPayAdditionInfoCreditCard,
     );
@@ -196,7 +196,7 @@ describe('NewebPay Refund Order', () => {
         bonusAmount: 0,
         closeBalance: 100,
         closeStatus: NewebPayCreditCardBalanceStatus.WORKING,
-        remainingBalance: 0,
+        remainingBalance: 100,
         refundStatus: NewebPayCreditCardBalanceStatus.UNSETTLED,
       } as NewebPayAdditionInfoCreditCard,
     );
@@ -213,7 +213,7 @@ describe('NewebPay Refund Order', () => {
     );
   });
 
-  it('should throw error when refund uncommitted order', () => {
+  it('should throw error when refund a fully-refunded order (state=REFUNDED, balance=0)', () => {
     const order = new NewebPayOrder<NewebPayCreditCardCommitMessage>(
       {
         id: '1291720470214',
@@ -246,11 +246,11 @@ describe('NewebPay Refund Order', () => {
         closeBalance: 100,
         closeStatus: NewebPayCreditCardBalanceStatus.WORKING,
         remainingBalance: 0,
-        refundStatus: NewebPayCreditCardBalanceStatus.UNSETTLED,
+        refundStatus: NewebPayCreditCardBalanceStatus.SETTLED,
       } as NewebPayAdditionInfoCreditCard,
     );
 
-    expect(() => order.refund()).rejects.toThrow('Only committed order can be refunded');
+    expect(order.refund()).rejects.toThrow('Only committed order can be refunded');
   });
 
   it('should throw error when refund non credit card order', () => {
@@ -350,7 +350,7 @@ describe('NewebPay Refund Order', () => {
         bonusAmount: 0,
         closeBalance: 100,
         closeStatus: NewebPayCreditCardBalanceStatus.SETTLED,
-        remainingBalance: 0,
+        remainingBalance: 100,
         refundStatus: NewebPayCreditCardBalanceStatus.UNSETTLED,
       } as NewebPayAdditionInfoCreditCard,
     );
@@ -390,7 +390,7 @@ describe('NewebPay Refund Order', () => {
         bonusAmount: 0,
         closeBalance: 100,
         closeStatus: NewebPayCreditCardBalanceStatus.UNSETTLED,
-        remainingBalance: 0,
+        remainingBalance: 100,
         refundStatus: NewebPayCreditCardBalanceStatus.UNSETTLED,
       } as NewebPayAdditionInfoCreditCard,
     );
@@ -677,7 +677,7 @@ describe('NewebPay Refund Order', () => {
         bonusAmount: 0,
         closeBalance: 100,
         closeStatus: NewebPayCreditCardBalanceStatus.SETTLED,
-        remainingBalance: 0,
+        remainingBalance: 100,
         refundStatus: NewebPayCreditCardBalanceStatus.UNSETTLED,
       } as NewebPayAdditionInfoCreditCard,
     );
@@ -788,7 +788,7 @@ describe('NewebPay Refund Order', () => {
         bonusAmount: 0,
         closeBalance: 100,
         closeStatus: NewebPayCreditCardBalanceStatus.SETTLED,
-        remainingBalance: 0,
+        remainingBalance: 100,
         refundStatus: NewebPayCreditCardBalanceStatus.UNSETTLED,
       } as NewebPayAdditionInfoCreditCard,
     );
@@ -830,12 +830,14 @@ describe('NewebPay Refund Order', () => {
         bonusAmount: 0,
         closeBalance: 100,
         closeStatus: NewebPayCreditCardBalanceStatus.SETTLED,
-        remainingBalance: 0,
+        remainingBalance: 100,
         refundStatus: NewebPayCreditCardBalanceStatus.UNSETTLED,
       } as NewebPayAdditionInfoCreditCard,
     );
 
-    await expect(payment.refund(order, 200)).rejects.toThrow('Refund amount cannot exceed order total price');
+    await expect(payment.refund(order, 200)).rejects.toThrow(
+      'Refund amount cannot exceed remaining refundable balance',
+    );
   });
 
   it('should throw error when partial refund amount is not a positive integer', async () => {
@@ -870,7 +872,7 @@ describe('NewebPay Refund Order', () => {
         bonusAmount: 0,
         closeBalance: 100,
         closeStatus: NewebPayCreditCardBalanceStatus.SETTLED,
-        remainingBalance: 0,
+        remainingBalance: 100,
         refundStatus: NewebPayCreditCardBalanceStatus.UNSETTLED,
       } as NewebPayAdditionInfoCreditCard,
     );
@@ -912,7 +914,7 @@ describe('NewebPay Refund Order', () => {
         bonusAmount: 0,
         closeBalance: 100,
         closeStatus: NewebPayCreditCardBalanceStatus.UNSETTLED,
-        remainingBalance: 0,
+        remainingBalance: 100,
         refundStatus: NewebPayCreditCardBalanceStatus.UNSETTLED,
       } as NewebPayAdditionInfoCreditCard,
     );
@@ -1075,5 +1077,200 @@ describe('NewebPay Refund Order', () => {
 
     await expect(payment.cancelRefund(order, 0)).rejects.toThrow('Cancel refund amount must be a positive integer');
     await expect(payment.cancelRefund(order, 25.5)).rejects.toThrow('Cancel refund amount must be a positive integer');
+  });
+
+  it('should allow another partial refund after a previous refund completed (BackBalance > 0)', async () => {
+    const mockedPost = jest.spyOn(axios, 'post');
+
+    mockedPost.mockImplementation(async (_url: string, data: string) => {
+      const payload = new URLSearchParams(data);
+      const postData = payload.get('PostData_');
+      const decipher = createDecipheriv('aes-256-cbc', AES_KEY, AES_IV);
+
+      const plainInfo = `${decipher.update(postData!, 'hex', 'utf8')}${decipher.final('utf8')}`;
+      const requestBody = new URLSearchParams(plainInfo);
+
+      expect(requestBody.get('CloseType')).toBe('2');
+      expect(requestBody.get('Amt')).toBe('30');
+
+      return {
+        data: {
+          Status: 'SUCCESS',
+          Message: '',
+          Result: {
+            CheckCode: createHash('sha256')
+              .update(`HashKey=${AES_KEY}&${postData}&HashIV=${AES_IV}`)
+              .digest('hex')
+              .toUpperCase(),
+          },
+        },
+      };
+    });
+
+    // Order that has been partially refunded once: original 100, refunded 40, balance 60.
+    // refundStatus=SETTLED means the previous refund completed.
+    const order = new NewebPayOrder<NewebPayCreditCardCommitMessage>(
+      {
+        id: 'order-with-prior-refund',
+        channel: NewebPaymentChannel.CREDIT,
+        items: [{ name: 'Test', quantity: 1, unitPrice: 100 }],
+        gateway: payment,
+        platformTradeNumber: '12937917203',
+        createdAt: new Date(),
+        committedAt: new Date(),
+        status: NewebPayOrderStatusFromAPI.COMMITTED,
+      },
+      {
+        channel: Channel.CREDIT_CARD,
+        processDate: new Date(),
+        authCode: '123123',
+        amount: 100,
+        eci: CreditCardECI.MASTER_3D,
+        card4Number: '9234',
+        card6Number: '124902',
+        authBank: 'Taishin',
+        subChannel: 'CREDIT',
+        speedCheckoutMode: NewebPayCreditCardSpeedCheckoutMode.NONE,
+        bonusAmount: 0,
+        closeBalance: 100,
+        closeStatus: NewebPayCreditCardBalanceStatus.SETTLED,
+        remainingBalance: 60, // 100 - prior 40 refund
+        refundStatus: NewebPayCreditCardBalanceStatus.SETTLED, // prior refund completed
+      } as NewebPayAdditionInfoCreditCard,
+    );
+
+    await payment.refund(order, 30); // 30 of remaining 60
+  });
+
+  it('should throw when refund amount exceeds remaining refundable balance', async () => {
+    const order = new NewebPayOrder<NewebPayCreditCardCommitMessage>(
+      {
+        id: 'over-balance',
+        channel: NewebPaymentChannel.CREDIT,
+        items: [{ name: 'Test', quantity: 1, unitPrice: 100 }],
+        gateway: payment,
+        platformTradeNumber: '12937917203',
+        createdAt: new Date(),
+        committedAt: new Date(),
+        status: NewebPayOrderStatusFromAPI.COMMITTED,
+      },
+      {
+        channel: Channel.CREDIT_CARD,
+        processDate: new Date(),
+        authCode: '123123',
+        amount: 100,
+        eci: CreditCardECI.MASTER_3D,
+        card4Number: '9234',
+        card6Number: '124902',
+        authBank: 'Taishin',
+        subChannel: 'CREDIT',
+        speedCheckoutMode: NewebPayCreditCardSpeedCheckoutMode.NONE,
+        bonusAmount: 0,
+        closeBalance: 100,
+        closeStatus: NewebPayCreditCardBalanceStatus.SETTLED,
+        remainingBalance: 60,
+        refundStatus: NewebPayCreditCardBalanceStatus.SETTLED,
+      } as NewebPayAdditionInfoCreditCard,
+    );
+
+    // 70 > remaining 60 — even though 70 < totalPrice 100
+    await expect(payment.refund(order, 70)).rejects.toThrow('Refund amount cannot exceed remaining refundable balance');
+  });
+
+  it('should throw when remaining refundable balance is zero', async () => {
+    const order = new NewebPayOrder<NewebPayCreditCardCommitMessage>(
+      {
+        id: 'fully-refunded',
+        channel: NewebPaymentChannel.CREDIT,
+        items: [{ name: 'Test', quantity: 1, unitPrice: 100 }],
+        gateway: payment,
+        platformTradeNumber: '12937917203',
+        createdAt: new Date(),
+        committedAt: new Date(),
+        status: NewebPayOrderStatusFromAPI.COMMITTED,
+      },
+      {
+        channel: Channel.CREDIT_CARD,
+        processDate: new Date(),
+        authCode: '123123',
+        amount: 100,
+        eci: CreditCardECI.MASTER_3D,
+        card4Number: '9234',
+        card6Number: '124902',
+        authBank: 'Taishin',
+        subChannel: 'CREDIT',
+        speedCheckoutMode: NewebPayCreditCardSpeedCheckoutMode.NONE,
+        bonusAmount: 0,
+        closeBalance: 100,
+        closeStatus: NewebPayCreditCardBalanceStatus.SETTLED,
+        remainingBalance: 0,
+        refundStatus: NewebPayCreditCardBalanceStatus.SETTLED,
+      } as NewebPayAdditionInfoCreditCard,
+    );
+
+    await expect(payment.refund(order)).rejects.toThrow('Order has no remaining refundable balance');
+    await expect(payment.refund(order, 10)).rejects.toThrow('Order has no remaining refundable balance');
+  });
+
+  it('should default refundAmount to remainingBalance when amount omitted on partially refunded order', async () => {
+    const mockedPost = jest.spyOn(axios, 'post');
+
+    mockedPost.mockImplementation(async (_url: string, data: string) => {
+      const payload = new URLSearchParams(data);
+      const postData = payload.get('PostData_');
+      const decipher = createDecipheriv('aes-256-cbc', AES_KEY, AES_IV);
+
+      const plainInfo = `${decipher.update(postData!, 'hex', 'utf8')}${decipher.final('utf8')}`;
+      const requestBody = new URLSearchParams(plainInfo);
+
+      expect(requestBody.get('CloseType')).toBe('2');
+      // Should send remaining 60, not original totalPrice 100
+      expect(requestBody.get('Amt')).toBe('60');
+
+      return {
+        data: {
+          Status: 'SUCCESS',
+          Message: '',
+          Result: {
+            CheckCode: createHash('sha256')
+              .update(`HashKey=${AES_KEY}&${postData}&HashIV=${AES_IV}`)
+              .digest('hex')
+              .toUpperCase(),
+          },
+        },
+      };
+    });
+
+    const order = new NewebPayOrder<NewebPayCreditCardCommitMessage>(
+      {
+        id: 'default-to-remaining',
+        channel: NewebPaymentChannel.CREDIT,
+        items: [{ name: 'Test', quantity: 1, unitPrice: 100 }],
+        gateway: payment,
+        platformTradeNumber: '12937917203',
+        createdAt: new Date(),
+        committedAt: new Date(),
+        status: NewebPayOrderStatusFromAPI.COMMITTED,
+      },
+      {
+        channel: Channel.CREDIT_CARD,
+        processDate: new Date(),
+        authCode: '123123',
+        amount: 100,
+        eci: CreditCardECI.MASTER_3D,
+        card4Number: '9234',
+        card6Number: '124902',
+        authBank: 'Taishin',
+        subChannel: 'CREDIT',
+        speedCheckoutMode: NewebPayCreditCardSpeedCheckoutMode.NONE,
+        bonusAmount: 0,
+        closeBalance: 100,
+        closeStatus: NewebPayCreditCardBalanceStatus.SETTLED,
+        remainingBalance: 60,
+        refundStatus: NewebPayCreditCardBalanceStatus.SETTLED,
+      } as NewebPayAdditionInfoCreditCard,
+    );
+
+    await payment.refund(order);
   });
 });

--- a/packages/payments-adapter-newebpay/__tests__/refund.spec.ts
+++ b/packages/payments-adapter-newebpay/__tests__/refund.spec.ts
@@ -1729,4 +1729,86 @@ describe('NewebPay Refund Order', () => {
     expect(order.state).toBe(OrderState.REFUNDED);
     expect(sentAmts).toEqual(['20', '20/cancel']);
   });
+
+  it('should keep remaining pending refund after partial cancelRefund amount', async () => {
+    const mockedPost = jest.spyOn(axios, 'post');
+
+    const sentAmts: string[] = [];
+
+    mockedPost.mockImplementation(async (_url: string, data: string) => {
+      const payload = new URLSearchParams(data);
+      const postData = payload.get('PostData_');
+      const decipher = createDecipheriv('aes-256-cbc', AES_KEY, AES_IV);
+
+      const plainInfo = `${decipher.update(postData!, 'hex', 'utf8')}${decipher.final('utf8')}`;
+      const requestBody = new URLSearchParams(plainInfo);
+
+      sentAmts.push(`${requestBody.get('Amt')}${requestBody.get('Cancel') ? '/cancel' : ''}`);
+
+      return {
+        data: {
+          Status: 'SUCCESS',
+          Message: '',
+          Result: {
+            CheckCode: createHash('sha256')
+              .update(`HashKey=${AES_KEY}&${postData}&HashIV=${AES_IV}`)
+              .digest('hex')
+              .toUpperCase(),
+          },
+        },
+      };
+    });
+
+    const order = new NewebPayOrder<NewebPayCreditCardCommitMessage>(
+      {
+        id: 'partial-cancel-keeps-pending',
+        channel: NewebPaymentChannel.CREDIT,
+        items: [{ name: 'Test', quantity: 1, unitPrice: 100 }],
+        gateway: payment,
+        platformTradeNumber: '12937917203',
+        createdAt: new Date(),
+        committedAt: new Date(),
+        status: NewebPayOrderStatusFromAPI.COMMITTED,
+      },
+      {
+        channel: Channel.CREDIT_CARD,
+        processDate: new Date(),
+        authCode: '123123',
+        amount: 100,
+        eci: CreditCardECI.MASTER_3D,
+        card4Number: '9234',
+        card6Number: '124902',
+        authBank: 'Taishin',
+        subChannel: 'CREDIT',
+        speedCheckoutMode: NewebPayCreditCardSpeedCheckoutMode.NONE,
+        bonusAmount: 0,
+        closeBalance: 100,
+        closeStatus: NewebPayCreditCardBalanceStatus.SETTLED,
+        remainingBalance: 100,
+        refundStatus: NewebPayCreditCardBalanceStatus.UNSETTLED,
+      } as NewebPayAdditionInfoCreditCard,
+    );
+
+    await order.refund(40);
+    await order.cancelRefund(10);
+
+    expect((order.additionalInfo as NewebPayAdditionInfoCreditCard).remainingBalance).toBe(70);
+    expect((order.additionalInfo as NewebPayAdditionInfoCreditCard).refundStatus).toBe(
+      NewebPayCreditCardBalanceStatus.WAITING,
+    );
+
+    expect(order.state).toBe(OrderState.REFUNDED);
+
+    await expect(order.refund(10)).rejects.toThrow('Order refunding.');
+
+    await order.cancelRefund();
+
+    expect((order.additionalInfo as NewebPayAdditionInfoCreditCard).remainingBalance).toBe(100);
+    expect((order.additionalInfo as NewebPayAdditionInfoCreditCard).refundStatus).toBe(
+      NewebPayCreditCardBalanceStatus.UNSETTLED,
+    );
+
+    expect(order.state).toBe(OrderState.COMMITTED);
+    expect(sentAmts).toEqual(['40', '10/cancel', '30/cancel']);
+  });
 });

--- a/packages/payments-adapter-newebpay/__tests__/refund.spec.ts
+++ b/packages/payments-adapter-newebpay/__tests__/refund.spec.ts
@@ -735,7 +735,10 @@ describe('NewebPay Refund Order', () => {
       const postData = payload.get('PostData_');
       const decipher = createDecipheriv('aes-256-cbc', AES_KEY, AES_IV);
 
-      const plainInfo = `${decipher.update(postData!, 'hex', 'utf8')}${decipher.final('utf8')}`.replace(/[ --]/g, '');
+      const plainInfo = `${decipher.update(postData!, 'hex', 'utf8')}${decipher.final('utf8')}`.replace(
+        /[\u0000-\u001F\u007F-\u009F]/g,
+        '',
+      );
 
       const requestBody = new URLSearchParams(plainInfo);
 
@@ -922,6 +925,141 @@ describe('NewebPay Refund Order', () => {
     await expect(order.refund(40)).rejects.toThrow('Partial refund only supported on working/settled orders');
   });
 
+  it('should throw when partial refund requested on installment order', async () => {
+    const order = new NewebPayOrder<NewebPayCreditCardCommitMessage>(
+      {
+        id: '1291720470214',
+        channel: NewebPaymentChannel.CREDIT,
+        items: [{ name: 'Test', quantity: 1, unitPrice: 1000 }],
+        gateway: payment,
+        platformTradeNumber: '12937917203',
+        createdAt: new Date(),
+        committedAt: new Date(),
+        status: NewebPayOrderStatusFromAPI.COMMITTED,
+      },
+      {
+        channel: Channel.CREDIT_CARD,
+        processDate: new Date(),
+        authCode: '123123',
+        amount: 1000,
+        eci: CreditCardECI.MASTER_3D,
+        card4Number: '9234',
+        card6Number: '124902',
+        authBank: 'Taishin',
+        subChannel: 'CREDIT',
+        speedCheckoutMode: NewebPayCreditCardSpeedCheckoutMode.NONE,
+        installments: { count: 3, firstAmount: 334, eachAmount: 333 },
+        bonusAmount: 0,
+        closeBalance: 1000,
+        closeStatus: NewebPayCreditCardBalanceStatus.SETTLED,
+        remainingBalance: 1000,
+        refundStatus: NewebPayCreditCardBalanceStatus.UNSETTLED,
+      } as NewebPayAdditionInfoCreditCard,
+    );
+
+    await expect(order.refund(400)).rejects.toThrow('Partial refund not supported for installment payments');
+  });
+
+  it('should throw when partial refund requested on bonus-discount order', async () => {
+    const order = new NewebPayOrder<NewebPayCreditCardCommitMessage>(
+      {
+        id: '1291720470214',
+        channel: NewebPaymentChannel.CREDIT,
+        items: [{ name: 'Test', quantity: 1, unitPrice: 1000 }],
+        gateway: payment,
+        platformTradeNumber: '12937917203',
+        createdAt: new Date(),
+        committedAt: new Date(),
+        status: NewebPayOrderStatusFromAPI.COMMITTED,
+      },
+      {
+        channel: Channel.CREDIT_CARD,
+        processDate: new Date(),
+        authCode: '123123',
+        amount: 940,
+        eci: CreditCardECI.MASTER_3D,
+        card4Number: '9234',
+        card6Number: '124902',
+        authBank: 'Taishin',
+        subChannel: 'CREDIT',
+        speedCheckoutMode: NewebPayCreditCardSpeedCheckoutMode.NONE,
+        bonusAmount: 60,
+        closeBalance: 940,
+        closeStatus: NewebPayCreditCardBalanceStatus.SETTLED,
+        remainingBalance: 940,
+        refundStatus: NewebPayCreditCardBalanceStatus.UNSETTLED,
+      } as NewebPayAdditionInfoCreditCard,
+    );
+
+    await expect(order.refund(400)).rejects.toThrow('Partial refund not supported for bonus-discount payments');
+  });
+
+  it('should allow full-amount refund on installment order via refund() (no arg)', async () => {
+    const mockedPost = jest.spyOn(axios, 'post');
+
+    let sentAmt: string | null = null;
+
+    mockedPost.mockImplementation(async (_url: string, data: string) => {
+      const payload = new URLSearchParams(data);
+      const postData = payload.get('PostData_');
+      const decipher = createDecipheriv('aes-256-cbc', AES_KEY, AES_IV);
+
+      const plainInfo = `${decipher.update(postData!, 'hex', 'utf8')}${decipher.final('utf8')}`;
+      const requestBody = new URLSearchParams(plainInfo);
+
+      sentAmt = requestBody.get('Amt');
+
+      return {
+        data: {
+          Status: 'SUCCESS',
+          Message: '',
+          Result: {
+            CheckCode: createHash('sha256')
+              .update(`HashKey=${AES_KEY}&${postData}&HashIV=${AES_IV}`)
+              .digest('hex')
+              .toUpperCase(),
+          },
+        },
+      };
+    });
+
+    const order = new NewebPayOrder<NewebPayCreditCardCommitMessage>(
+      {
+        id: '1291720470214',
+        channel: NewebPaymentChannel.CREDIT,
+        items: [{ name: 'Test', quantity: 1, unitPrice: 1000 }],
+        gateway: payment,
+        platformTradeNumber: '12937917203',
+        createdAt: new Date(),
+        committedAt: new Date(),
+        status: NewebPayOrderStatusFromAPI.COMMITTED,
+      },
+      {
+        channel: Channel.CREDIT_CARD,
+        processDate: new Date(),
+        authCode: '123123',
+        amount: 1000,
+        eci: CreditCardECI.MASTER_3D,
+        card4Number: '9234',
+        card6Number: '124902',
+        authBank: 'Taishin',
+        subChannel: 'CREDIT',
+        speedCheckoutMode: NewebPayCreditCardSpeedCheckoutMode.NONE,
+        installments: { count: 3, firstAmount: 334, eachAmount: 333 },
+        bonusAmount: 0,
+        closeBalance: 1000,
+        closeStatus: NewebPayCreditCardBalanceStatus.SETTLED,
+        remainingBalance: 1000,
+        refundStatus: NewebPayCreditCardBalanceStatus.UNSETTLED,
+      } as NewebPayAdditionInfoCreditCard,
+    );
+
+    await order.refund();
+
+    expect(sentAmt).toBe('1000');
+    expect((order.additionalInfo as NewebPayAdditionInfoCreditCard).remainingBalance).toBe(0);
+  });
+
   it('should cancel refund partial amount when amount is provided', async () => {
     const mockedPost = jest.spyOn(axios, 'post');
 
@@ -932,7 +1070,10 @@ describe('NewebPay Refund Order', () => {
       const postData = payload.get('PostData_');
       const decipher = createDecipheriv('aes-256-cbc', AES_KEY, AES_IV);
 
-      const plainInfo = `${decipher.update(postData!, 'hex', 'utf8')}${decipher.final('utf8')}`.replace(/[ --]/g, '');
+      const plainInfo = `${decipher.update(postData!, 'hex', 'utf8')}${decipher.final('utf8')}`.replace(
+        /[\u0000-\u001F\u007F-\u009F]/g,
+        '',
+      );
 
       const requestBody = new URLSearchParams(plainInfo);
 
@@ -1080,6 +1221,79 @@ describe('NewebPay Refund Order', () => {
 
     await expect(payment.cancelRefund(order, 0)).rejects.toThrow('Cancel refund amount must be a positive integer');
     await expect(payment.cancelRefund(order, 25.5)).rejects.toThrow('Cancel refund amount must be a positive integer');
+  });
+
+  it('should throw when partial cancel refund requested on installment order', async () => {
+    const order = new NewebPayOrder<NewebPayCreditCardCommitMessage>(
+      {
+        id: '1291720470214',
+        channel: NewebPaymentChannel.CREDIT,
+        items: [{ name: 'Test', quantity: 1, unitPrice: 1000 }],
+        gateway: payment,
+        platformTradeNumber: '12937917203',
+        createdAt: new Date(),
+        committedAt: new Date(),
+        status: NewebPayOrderStatusFromAPI.REFUNDED,
+      },
+      {
+        channel: Channel.CREDIT_CARD,
+        processDate: new Date(),
+        authCode: '123123',
+        amount: 1000,
+        eci: CreditCardECI.MASTER_3D,
+        card4Number: '9234',
+        card6Number: '124902',
+        authBank: 'Taishin',
+        subChannel: 'CREDIT',
+        speedCheckoutMode: NewebPayCreditCardSpeedCheckoutMode.NONE,
+        installments: { count: 3, firstAmount: 334, eachAmount: 333 },
+        bonusAmount: 0,
+        closeBalance: 1000,
+        closeStatus: NewebPayCreditCardBalanceStatus.SETTLED,
+        remainingBalance: 0,
+        refundStatus: NewebPayCreditCardBalanceStatus.WAITING,
+      } as NewebPayAdditionInfoCreditCard,
+    );
+
+    await expect(payment.cancelRefund(order, 400)).rejects.toThrow(
+      'Partial cancel refund not supported for installment payments',
+    );
+  });
+
+  it('should throw when partial cancel refund requested on bonus-discount order', async () => {
+    const order = new NewebPayOrder<NewebPayCreditCardCommitMessage>(
+      {
+        id: '1291720470214',
+        channel: NewebPaymentChannel.CREDIT,
+        items: [{ name: 'Test', quantity: 1, unitPrice: 940 }],
+        gateway: payment,
+        platformTradeNumber: '12937917203',
+        createdAt: new Date(),
+        committedAt: new Date(),
+        status: NewebPayOrderStatusFromAPI.REFUNDED,
+      },
+      {
+        channel: Channel.CREDIT_CARD,
+        processDate: new Date(),
+        authCode: '123123',
+        amount: 940,
+        eci: CreditCardECI.MASTER_3D,
+        card4Number: '9234',
+        card6Number: '124902',
+        authBank: 'Taishin',
+        subChannel: 'CREDIT',
+        speedCheckoutMode: NewebPayCreditCardSpeedCheckoutMode.NONE,
+        bonusAmount: 60,
+        closeBalance: 940,
+        closeStatus: NewebPayCreditCardBalanceStatus.SETTLED,
+        remainingBalance: 0,
+        refundStatus: NewebPayCreditCardBalanceStatus.WAITING,
+      } as NewebPayAdditionInfoCreditCard,
+    );
+
+    await expect(payment.cancelRefund(order, 400)).rejects.toThrow(
+      'Partial cancel refund not supported for bonus-discount payments',
+    );
   });
 
   it('should allow another partial refund after a previous refund completed (BackBalance > 0)', async () => {
@@ -1277,7 +1491,7 @@ describe('NewebPay Refund Order', () => {
     await payment.refund(order);
   });
 
-  it('should round-trip refund(40) → cancelRefund(40) → refund(60) restoring then re-spending balance', async () => {
+  it('should round-trip refund(40) → cancelRefund() → refund() defaulting to restored balance', async () => {
     const mockedPost = jest.spyOn(axios, 'post');
 
     const sentAmts: string[] = [];
@@ -1352,10 +1566,10 @@ describe('NewebPay Refund Order', () => {
 
     expect(order.state).toBe(OrderState.COMMITTED);
 
-    // New refund of 60 should be allowed and use the restored balance
-    await order.refund(60);
-    expect((order.additionalInfo as NewebPayAdditionInfoCreditCard).remainingBalance).toBe(40);
+    // refund() with no amount should default to the restored remainingBalance (100)
+    await order.refund();
+    expect((order.additionalInfo as NewebPayAdditionInfoCreditCard).remainingBalance).toBe(0);
 
-    expect(sentAmts).toEqual(['40', '40/cancel', '60']);
+    expect(sentAmts).toEqual(['40', '40/cancel', '100']);
   });
 });

--- a/packages/payments-adapter-newebpay/__tests__/refund.spec.ts
+++ b/packages/payments-adapter-newebpay/__tests__/refund.spec.ts
@@ -724,4 +724,356 @@ describe('NewebPay Refund Order', () => {
 
     expect(() => payment.cancelRefund(order)).rejects.toThrow('Only refunded order can be cancel refund');
   });
+
+  it('should refund partial amount when amount is provided', async () => {
+    const mockedPost = jest.spyOn(axios, 'post');
+
+    mockedPost.mockImplementation(async (url: string, data: string) => {
+      expect(url).toMatch(/\/API\/CreditCard\/Close$/);
+
+      const payload = new URLSearchParams(data);
+      const postData = payload.get('PostData_');
+      const decipher = createDecipheriv('aes-256-cbc', AES_KEY, AES_IV);
+
+      const plainInfo = `${decipher.update(postData!, 'hex', 'utf8')}${decipher.final('utf8')}`.replace(/[ --]/g, '');
+
+      const requestBody = new URLSearchParams(plainInfo);
+
+      expect(requestBody.get('CloseType')).toBe('2');
+      expect(requestBody.get('Amt')).toBe('40');
+      expect(requestBody.get('MerchantOrderNo')).toBe('1291720470214');
+
+      return {
+        data: {
+          Status: 'SUCCESS',
+          Message: '',
+          Result: {
+            CheckCode: createHash('sha256')
+              .update(`HashKey=${AES_KEY}&${postData}&HashIV=${AES_IV}`)
+              .digest('hex')
+              .toUpperCase(),
+          },
+        },
+      };
+    });
+
+    const order = new NewebPayOrder<NewebPayCreditCardCommitMessage>(
+      {
+        id: '1291720470214',
+        channel: NewebPaymentChannel.CREDIT,
+        items: [
+          {
+            name: 'Test',
+            quantity: 1,
+            unitPrice: 100,
+          },
+        ],
+        gateway: payment,
+        platformTradeNumber: '12937917203',
+        createdAt: new Date(),
+        committedAt: new Date(),
+        status: NewebPayOrderStatusFromAPI.COMMITTED,
+      },
+      {
+        channel: Channel.CREDIT_CARD,
+        processDate: new Date(),
+        authCode: '123123',
+        amount: 100,
+        eci: CreditCardECI.MASTER_3D,
+        card4Number: '9234',
+        card6Number: '124902',
+        authBank: 'Taishin',
+        subChannel: 'CREDIT',
+        speedCheckoutMode: NewebPayCreditCardSpeedCheckoutMode.NONE,
+        bonusAmount: 0,
+        closeBalance: 100,
+        closeStatus: NewebPayCreditCardBalanceStatus.SETTLED,
+        remainingBalance: 0,
+        refundStatus: NewebPayCreditCardBalanceStatus.UNSETTLED,
+      } as NewebPayAdditionInfoCreditCard,
+    );
+
+    await order.refund(40);
+
+    expect(order.state).toBe(OrderState.REFUNDED);
+  });
+
+  it('should throw error when partial refund amount exceeds total price', async () => {
+    const order = new NewebPayOrder<NewebPayCreditCardCommitMessage>(
+      {
+        id: '1291720470214',
+        channel: NewebPaymentChannel.CREDIT,
+        items: [
+          {
+            name: 'Test',
+            quantity: 1,
+            unitPrice: 100,
+          },
+        ],
+        gateway: payment,
+        platformTradeNumber: '12937917203',
+        createdAt: new Date(),
+        committedAt: new Date(),
+        status: NewebPayOrderStatusFromAPI.COMMITTED,
+      },
+      {
+        channel: Channel.CREDIT_CARD,
+        processDate: new Date(),
+        authCode: '123123',
+        amount: 100,
+        eci: CreditCardECI.MASTER_3D,
+        card4Number: '9234',
+        card6Number: '124902',
+        authBank: 'Taishin',
+        subChannel: 'CREDIT',
+        speedCheckoutMode: NewebPayCreditCardSpeedCheckoutMode.NONE,
+        bonusAmount: 0,
+        closeBalance: 100,
+        closeStatus: NewebPayCreditCardBalanceStatus.SETTLED,
+        remainingBalance: 0,
+        refundStatus: NewebPayCreditCardBalanceStatus.UNSETTLED,
+      } as NewebPayAdditionInfoCreditCard,
+    );
+
+    await expect(payment.refund(order, 200)).rejects.toThrow('Refund amount cannot exceed order total price');
+  });
+
+  it('should throw error when partial refund amount is not a positive integer', async () => {
+    const order = new NewebPayOrder<NewebPayCreditCardCommitMessage>(
+      {
+        id: '1291720470214',
+        channel: NewebPaymentChannel.CREDIT,
+        items: [
+          {
+            name: 'Test',
+            quantity: 1,
+            unitPrice: 100,
+          },
+        ],
+        gateway: payment,
+        platformTradeNumber: '12937917203',
+        createdAt: new Date(),
+        committedAt: new Date(),
+        status: NewebPayOrderStatusFromAPI.COMMITTED,
+      },
+      {
+        channel: Channel.CREDIT_CARD,
+        processDate: new Date(),
+        authCode: '123123',
+        amount: 100,
+        eci: CreditCardECI.MASTER_3D,
+        card4Number: '9234',
+        card6Number: '124902',
+        authBank: 'Taishin',
+        subChannel: 'CREDIT',
+        speedCheckoutMode: NewebPayCreditCardSpeedCheckoutMode.NONE,
+        bonusAmount: 0,
+        closeBalance: 100,
+        closeStatus: NewebPayCreditCardBalanceStatus.SETTLED,
+        remainingBalance: 0,
+        refundStatus: NewebPayCreditCardBalanceStatus.UNSETTLED,
+      } as NewebPayAdditionInfoCreditCard,
+    );
+
+    await expect(payment.refund(order, 0)).rejects.toThrow('Refund amount must be a positive integer');
+    await expect(payment.refund(order, -10)).rejects.toThrow('Refund amount must be a positive integer');
+    await expect(payment.refund(order, 12.5)).rejects.toThrow('Refund amount must be a positive integer');
+  });
+
+  it('should throw error when partial refund requested on unsettled order', async () => {
+    const order = new NewebPayOrder<NewebPayCreditCardCommitMessage>(
+      {
+        id: '1291720470214',
+        channel: NewebPaymentChannel.CREDIT,
+        items: [
+          {
+            name: 'Test',
+            quantity: 1,
+            unitPrice: 100,
+          },
+        ],
+        gateway: payment,
+        platformTradeNumber: '12937917203',
+        createdAt: new Date(),
+        committedAt: new Date(),
+        status: NewebPayOrderStatusFromAPI.COMMITTED,
+      },
+      {
+        channel: Channel.CREDIT_CARD,
+        processDate: new Date(),
+        authCode: '123123',
+        amount: 100,
+        eci: CreditCardECI.MASTER_3D,
+        card4Number: '9234',
+        card6Number: '124902',
+        authBank: 'Taishin',
+        subChannel: 'CREDIT',
+        speedCheckoutMode: NewebPayCreditCardSpeedCheckoutMode.NONE,
+        bonusAmount: 0,
+        closeBalance: 100,
+        closeStatus: NewebPayCreditCardBalanceStatus.UNSETTLED,
+        remainingBalance: 0,
+        refundStatus: NewebPayCreditCardBalanceStatus.UNSETTLED,
+      } as NewebPayAdditionInfoCreditCard,
+    );
+
+    await expect(order.refund(40)).rejects.toThrow('Partial refund only supported on working/settled orders');
+  });
+
+  it('should cancel refund partial amount when amount is provided', async () => {
+    const mockedPost = jest.spyOn(axios, 'post');
+
+    mockedPost.mockImplementation(async (url: string, data: string) => {
+      expect(url).toMatch(/\/API\/CreditCard\/Close$/);
+
+      const payload = new URLSearchParams(data);
+      const postData = payload.get('PostData_');
+      const decipher = createDecipheriv('aes-256-cbc', AES_KEY, AES_IV);
+
+      const plainInfo = `${decipher.update(postData!, 'hex', 'utf8')}${decipher.final('utf8')}`.replace(/[ --]/g, '');
+
+      const requestBody = new URLSearchParams(plainInfo);
+
+      expect(requestBody.get('CloseType')).toBe('2');
+      expect(requestBody.get('Cancel')).toBe('1');
+      expect(requestBody.get('Amt')).toBe('30');
+      expect(requestBody.get('MerchantOrderNo')).toBe('1291720470214');
+
+      return {
+        data: {
+          Status: 'SUCCESS',
+          Message: '',
+          Result: {
+            CheckCode: createHash('sha256')
+              .update(`HashKey=${AES_KEY}&${postData}&HashIV=${AES_IV}`)
+              .digest('hex')
+              .toUpperCase(),
+          },
+        },
+      };
+    });
+
+    const order = new NewebPayOrder<NewebPayCreditCardCommitMessage>(
+      {
+        id: '1291720470214',
+        channel: NewebPaymentChannel.CREDIT,
+        items: [
+          {
+            name: 'Test',
+            quantity: 1,
+            unitPrice: 100,
+          },
+        ],
+        gateway: payment,
+        platformTradeNumber: '12937917203',
+        createdAt: new Date(),
+        committedAt: new Date(),
+        status: NewebPayOrderStatusFromAPI.REFUNDED,
+      },
+      {
+        channel: Channel.CREDIT_CARD,
+        processDate: new Date(),
+        authCode: '123123',
+        amount: 100,
+        eci: CreditCardECI.MASTER_3D,
+        card4Number: '9234',
+        card6Number: '124902',
+        authBank: 'Taishin',
+        subChannel: 'CREDIT',
+        speedCheckoutMode: NewebPayCreditCardSpeedCheckoutMode.NONE,
+        bonusAmount: 0,
+        closeBalance: 100,
+        closeStatus: NewebPayCreditCardBalanceStatus.SETTLED,
+        remainingBalance: 0,
+        refundStatus: NewebPayCreditCardBalanceStatus.WAITING,
+      } as NewebPayAdditionInfoCreditCard,
+    );
+
+    await order.cancelRefund(30);
+
+    expect(order.state).toBe(OrderState.COMMITTED);
+  });
+
+  it('should throw error when partial cancel refund amount exceeds total price', async () => {
+    const order = new NewebPayOrder<NewebPayCreditCardCommitMessage>(
+      {
+        id: '1291720470214',
+        channel: NewebPaymentChannel.CREDIT,
+        items: [
+          {
+            name: 'Test',
+            quantity: 1,
+            unitPrice: 100,
+          },
+        ],
+        gateway: payment,
+        platformTradeNumber: '12937917203',
+        createdAt: new Date(),
+        committedAt: new Date(),
+        status: NewebPayOrderStatusFromAPI.REFUNDED,
+      },
+      {
+        channel: Channel.CREDIT_CARD,
+        processDate: new Date(),
+        authCode: '123123',
+        amount: 100,
+        eci: CreditCardECI.MASTER_3D,
+        card4Number: '9234',
+        card6Number: '124902',
+        authBank: 'Taishin',
+        subChannel: 'CREDIT',
+        speedCheckoutMode: NewebPayCreditCardSpeedCheckoutMode.NONE,
+        bonusAmount: 0,
+        closeBalance: 100,
+        closeStatus: NewebPayCreditCardBalanceStatus.SETTLED,
+        remainingBalance: 0,
+        refundStatus: NewebPayCreditCardBalanceStatus.WAITING,
+      } as NewebPayAdditionInfoCreditCard,
+    );
+
+    await expect(payment.cancelRefund(order, 200)).rejects.toThrow(
+      'Cancel refund amount cannot exceed order total price',
+    );
+  });
+
+  it('should throw error when partial cancel refund amount is not a positive integer', async () => {
+    const order = new NewebPayOrder<NewebPayCreditCardCommitMessage>(
+      {
+        id: '1291720470214',
+        channel: NewebPaymentChannel.CREDIT,
+        items: [
+          {
+            name: 'Test',
+            quantity: 1,
+            unitPrice: 100,
+          },
+        ],
+        gateway: payment,
+        platformTradeNumber: '12937917203',
+        createdAt: new Date(),
+        committedAt: new Date(),
+        status: NewebPayOrderStatusFromAPI.REFUNDED,
+      },
+      {
+        channel: Channel.CREDIT_CARD,
+        processDate: new Date(),
+        authCode: '123123',
+        amount: 100,
+        eci: CreditCardECI.MASTER_3D,
+        card4Number: '9234',
+        card6Number: '124902',
+        authBank: 'Taishin',
+        subChannel: 'CREDIT',
+        speedCheckoutMode: NewebPayCreditCardSpeedCheckoutMode.NONE,
+        bonusAmount: 0,
+        closeBalance: 100,
+        closeStatus: NewebPayCreditCardBalanceStatus.SETTLED,
+        remainingBalance: 0,
+        refundStatus: NewebPayCreditCardBalanceStatus.WAITING,
+      } as NewebPayAdditionInfoCreditCard,
+    );
+
+    await expect(payment.cancelRefund(order, 0)).rejects.toThrow('Cancel refund amount must be a positive integer');
+    await expect(payment.cancelRefund(order, 25.5)).rejects.toThrow('Cancel refund amount must be a positive integer');
+  });
 });

--- a/packages/payments-adapter-newebpay/__tests__/refund.spec.ts
+++ b/packages/payments-adapter-newebpay/__tests__/refund.spec.ts
@@ -213,7 +213,7 @@ describe('NewebPay Refund Order', () => {
     );
   });
 
-  it('should throw error when refund a fully-refunded order (state=REFUNDED, balance=0)', () => {
+  it('should throw error when refund a fully-refunded order (state=REFUNDED, balance=0)', async () => {
     const order = new NewebPayOrder<NewebPayCreditCardCommitMessage>(
       {
         id: '1291720470214',
@@ -250,7 +250,7 @@ describe('NewebPay Refund Order', () => {
       } as NewebPayAdditionInfoCreditCard,
     );
 
-    expect(order.refund()).rejects.toThrow('Only committed order can be refunded');
+    await expect(order.refund()).rejects.toThrow('Only committed order can be refunded');
   });
 
   it('should throw error when refund non credit card order', () => {
@@ -986,7 +986,9 @@ describe('NewebPay Refund Order', () => {
         bonusAmount: 0,
         closeBalance: 100,
         closeStatus: NewebPayCreditCardBalanceStatus.SETTLED,
-        remainingBalance: 0,
+        // 30 was refunded (pending) → remainingBalance=70.  Cancelling that 30
+        // restores remainingBalance to 100 and returns the order to COMMITTED.
+        remainingBalance: 70,
         refundStatus: NewebPayCreditCardBalanceStatus.WAITING,
       } as NewebPayAdditionInfoCreditCard,
     );
@@ -994,6 +996,7 @@ describe('NewebPay Refund Order', () => {
     await order.cancelRefund(30);
 
     expect(order.state).toBe(OrderState.COMMITTED);
+    expect((order.additionalInfo as NewebPayAdditionInfoCreditCard).remainingBalance).toBe(100);
   });
 
   it('should throw error when partial cancel refund amount exceeds total price', async () => {
@@ -1034,7 +1037,7 @@ describe('NewebPay Refund Order', () => {
     );
 
     await expect(payment.cancelRefund(order, 200)).rejects.toThrow(
-      'Cancel refund amount cannot exceed order total price',
+      'Cancel refund amount cannot exceed refunded amount',
     );
   });
 
@@ -1272,5 +1275,87 @@ describe('NewebPay Refund Order', () => {
     );
 
     await payment.refund(order);
+  });
+
+  it('should round-trip refund(40) → cancelRefund(40) → refund(60) restoring then re-spending balance', async () => {
+    const mockedPost = jest.spyOn(axios, 'post');
+
+    const sentAmts: string[] = [];
+
+    mockedPost.mockImplementation(async (_url: string, data: string) => {
+      const payload = new URLSearchParams(data);
+      const postData = payload.get('PostData_');
+      const decipher = createDecipheriv('aes-256-cbc', AES_KEY, AES_IV);
+
+      const plainInfo = `${decipher.update(postData!, 'hex', 'utf8')}${decipher.final('utf8')}`;
+      const requestBody = new URLSearchParams(plainInfo);
+
+      sentAmts.push(`${requestBody.get('Amt')}${requestBody.get('Cancel') ? '/cancel' : ''}`);
+
+      return {
+        data: {
+          Status: 'SUCCESS',
+          Message: '',
+          Result: {
+            CheckCode: createHash('sha256')
+              .update(`HashKey=${AES_KEY}&${postData}&HashIV=${AES_IV}`)
+              .digest('hex')
+              .toUpperCase(),
+          },
+        },
+      };
+    });
+
+    const order = new NewebPayOrder<NewebPayCreditCardCommitMessage>(
+      {
+        id: 'round-trip',
+        channel: NewebPaymentChannel.CREDIT,
+        items: [{ name: 'Test', quantity: 1, unitPrice: 100 }],
+        gateway: payment,
+        platformTradeNumber: '12937917203',
+        createdAt: new Date(),
+        committedAt: new Date(),
+        status: NewebPayOrderStatusFromAPI.COMMITTED,
+      },
+      {
+        channel: Channel.CREDIT_CARD,
+        processDate: new Date(),
+        authCode: '123123',
+        amount: 100,
+        eci: CreditCardECI.MASTER_3D,
+        card4Number: '9234',
+        card6Number: '124902',
+        authBank: 'Taishin',
+        subChannel: 'CREDIT',
+        speedCheckoutMode: NewebPayCreditCardSpeedCheckoutMode.NONE,
+        bonusAmount: 0,
+        closeBalance: 100,
+        closeStatus: NewebPayCreditCardBalanceStatus.SETTLED,
+        remainingBalance: 100,
+        refundStatus: NewebPayCreditCardBalanceStatus.UNSETTLED,
+      } as NewebPayAdditionInfoCreditCard,
+    );
+
+    // First refund of 40 → remainingBalance 60, refundStatus WAITING
+    await order.refund(40);
+    expect((order.additionalInfo as NewebPayAdditionInfoCreditCard).remainingBalance).toBe(60);
+    expect((order.additionalInfo as NewebPayAdditionInfoCreditCard).refundStatus).toBe(
+      NewebPayCreditCardBalanceStatus.WAITING,
+    );
+
+    // Cancel that 40 → remainingBalance back to 100, refundStatus UNSETTLED, state COMMITTED
+    await order.cancelRefund();
+    expect((order.additionalInfo as NewebPayAdditionInfoCreditCard).remainingBalance).toBe(100);
+    expect((order.additionalInfo as NewebPayAdditionInfoCreditCard).refundStatus).toBe(
+      NewebPayCreditCardBalanceStatus.UNSETTLED,
+    );
+
+    expect(order.state).toBe(OrderState.COMMITTED);
+
+    // New refund of 60 should be allowed and use the restored balance
+    await order.refund(60);
+    expect((order.additionalInfo as NewebPayAdditionInfoCreditCard).remainingBalance).toBe(40);
+
+    expect(sentAmts).toEqual(['40', '40/cancel', '60']);
   });
 });

--- a/packages/payments-adapter-newebpay/src/newebpay-order.ts
+++ b/packages/payments-adapter-newebpay/src/newebpay-order.ts
@@ -239,9 +239,7 @@ export class NewebPayOrder<OCM extends NewebPayCommitMessage = NewebPayCommitMes
   }
 
   async cancelRefund(amount?: number): Promise<void> {
-    const ai = this.additionalInfo as AdditionalInfo<NewebPayCreditCardCommitMessage> | undefined as
-      | NewebPayAdditionInfoCreditCard
-      | undefined;
+    const ai = this.additionalInfo as NewebPayAdditionInfoCreditCard | undefined;
 
     const refundedSoFar = this.totalPrice - (ai?.remainingBalance ?? this.totalPrice);
     const cancelAmount = amount ?? this._pendingRefundAmount ?? refundedSoFar;
@@ -281,9 +279,7 @@ export class NewebPayOrder<OCM extends NewebPayCommitMessage = NewebPayCommitMes
   }
 
   async refund(amount?: number): Promise<void> {
-    const additionalInfo = this.additionalInfo as AdditionalInfo<NewebPayCreditCardCommitMessage> | undefined as
-      | NewebPayAdditionInfoCreditCard
-      | undefined;
+    const additionalInfo = this.additionalInfo as NewebPayAdditionInfoCreditCard | undefined;
 
     const remainingBalance = additionalInfo?.remainingBalance ?? this.totalPrice;
 

--- a/packages/payments-adapter-newebpay/src/newebpay-order.ts
+++ b/packages/payments-adapter-newebpay/src/newebpay-order.ts
@@ -232,8 +232,8 @@ export class NewebPayOrder<OCM extends NewebPayCommitMessage = NewebPayCommitMes
     ).closeStatus = NewebPayCreditCardBalanceStatus.WAITING;
   }
 
-  async cancelRefund(): Promise<void> {
-    await this._gateway.cancelRefund(this as NewebPayOrder<NewebPayCreditCardCommitMessage>);
+  async cancelRefund(amount?: number): Promise<void> {
+    await this._gateway.cancelRefund(this as NewebPayOrder<NewebPayCreditCardCommitMessage>, amount);
 
     (
       this.additionalInfo as AdditionalInfo<NewebPayCreditCardCommitMessage> as NewebPayAdditionInfoCreditCard
@@ -242,7 +242,7 @@ export class NewebPayOrder<OCM extends NewebPayCommitMessage = NewebPayCommitMes
     this._state = OrderState.COMMITTED;
   }
 
-  async refund(): Promise<void> {
+  async refund(amount?: number): Promise<void> {
     if (this._state !== OrderState.COMMITTED) {
       throw new Error('Only committed order can be refunded');
     }
@@ -254,6 +254,14 @@ export class NewebPayOrder<OCM extends NewebPayCommitMessage = NewebPayCommitMes
     const closeStatus = (
       this.additionalInfo as AdditionalInfo<NewebPayCreditCardCommitMessage> as NewebPayAdditionInfoCreditCard
     ).closeStatus;
+
+    if (
+      amount !== undefined &&
+      closeStatus !== NewebPayCreditCardBalanceStatus.WORKING &&
+      closeStatus !== NewebPayCreditCardBalanceStatus.SETTLED
+    ) {
+      throw new Error('Partial refund only supported on working/settled orders');
+    }
 
     switch (closeStatus) {
       case NewebPayCreditCardBalanceStatus.UNSETTLED:
@@ -278,7 +286,7 @@ export class NewebPayOrder<OCM extends NewebPayCommitMessage = NewebPayCommitMes
 
       case NewebPayCreditCardBalanceStatus.WORKING:
       case NewebPayCreditCardBalanceStatus.SETTLED:
-        await this._gateway.refund(this as NewebPayOrder<NewebPayCreditCardCommitMessage>);
+        await this._gateway.refund(this as NewebPayOrder<NewebPayCreditCardCommitMessage>, amount);
 
         (
           this.additionalInfo as AdditionalInfo<NewebPayCreditCardCommitMessage> as NewebPayAdditionInfoCreditCard

--- a/packages/payments-adapter-newebpay/src/newebpay-order.ts
+++ b/packages/payments-adapter-newebpay/src/newebpay-order.ts
@@ -249,7 +249,20 @@ export class NewebPayOrder<OCM extends NewebPayCommitMessage = NewebPayCommitMes
     await this._gateway.cancelRefund(this as NewebPayOrder<NewebPayCreditCardCommitMessage>, cancelAmount);
 
     if (ai) {
+      const pendingRefundAmount = this._pendingRefundAmount;
+      const remainingPendingRefundAmount =
+        pendingRefundAmount === undefined ? undefined : pendingRefundAmount - cancelAmount;
+
       ai.remainingBalance = (ai.remainingBalance ?? 0) + cancelAmount;
+
+      if (remainingPendingRefundAmount !== undefined && remainingPendingRefundAmount > 0) {
+        this._pendingRefundAmount = remainingPendingRefundAmount;
+        ai.refundStatus = NewebPayCreditCardBalanceStatus.WAITING;
+        this._state = OrderState.REFUNDED;
+
+        return;
+      }
+
       this._pendingRefundAmount = undefined;
 
       // After cancelling, refundStatus only resets to UNSETTLED if no prior refund

--- a/packages/payments-adapter-newebpay/src/newebpay-order.ts
+++ b/packages/payments-adapter-newebpay/src/newebpay-order.ts
@@ -39,6 +39,8 @@ export class NewebPayOrder<OCM extends NewebPayCommitMessage = NewebPayCommitMes
 
   private _additionalInfo?: AdditionalInfo<OCM>;
 
+  private _pendingRefundAmount: number | undefined;
+
   constructor(
     options: NewebPayPrepareOrderInit<OCM> | NewebPayOrderFromServerInit<OCM>,
     additionalInfo?: AdditionalInfo<OCM>,
@@ -173,6 +175,10 @@ export class NewebPayOrder<OCM extends NewebPayCommitMessage = NewebPayCommitMes
     return this._additionalInfo;
   }
 
+  get pendingRefundAmount(): number | undefined {
+    return this._pendingRefundAmount;
+  }
+
   get platformTradeNumber(): string | null {
     return this._platformTradeNumber;
   }
@@ -238,12 +244,13 @@ export class NewebPayOrder<OCM extends NewebPayCommitMessage = NewebPayCommitMes
       | undefined;
 
     const refundedSoFar = this.totalPrice - (ai?.remainingBalance ?? this.totalPrice);
-    const cancelAmount = amount ?? refundedSoFar;
+    const cancelAmount = amount ?? this._pendingRefundAmount ?? refundedSoFar;
 
     await this._gateway.cancelRefund(this as NewebPayOrder<NewebPayCreditCardCommitMessage>, cancelAmount);
 
     if (ai) {
       ai.remainingBalance = (ai.remainingBalance ?? 0) + cancelAmount;
+      this._pendingRefundAmount = undefined;
 
       // After cancelling, refundStatus only resets to UNSETTLED if no prior refund
       // remains in flight or completed (i.e. balance restored to totalPrice).
@@ -326,6 +333,7 @@ export class NewebPayOrder<OCM extends NewebPayCommitMessage = NewebPayCommitMes
         ai.closeStatus = NewebPayCreditCardBalanceStatus.SETTLED;
         ai.refundStatus = NewebPayCreditCardBalanceStatus.WAITING;
         ai.remainingBalance = remainingBalance - refundAmount;
+        this._pendingRefundAmount = refundAmount;
 
         this._state = OrderState.REFUNDED;
         break;

--- a/packages/payments-adapter-newebpay/src/newebpay-order.ts
+++ b/packages/payments-adapter-newebpay/src/newebpay-order.ts
@@ -233,13 +233,31 @@ export class NewebPayOrder<OCM extends NewebPayCommitMessage = NewebPayCommitMes
   }
 
   async cancelRefund(amount?: number): Promise<void> {
-    await this._gateway.cancelRefund(this as NewebPayOrder<NewebPayCreditCardCommitMessage>, amount);
+    const ai = this.additionalInfo as AdditionalInfo<NewebPayCreditCardCommitMessage> | undefined as
+      | NewebPayAdditionInfoCreditCard
+      | undefined;
 
-    (
-      this.additionalInfo as AdditionalInfo<NewebPayCreditCardCommitMessage> as NewebPayAdditionInfoCreditCard
-    ).refundStatus = NewebPayCreditCardBalanceStatus.UNSETTLED;
+    const refundedSoFar = this.totalPrice - (ai?.remainingBalance ?? this.totalPrice);
+    const cancelAmount = amount ?? refundedSoFar;
 
-    this._state = OrderState.COMMITTED;
+    await this._gateway.cancelRefund(this as NewebPayOrder<NewebPayCreditCardCommitMessage>, cancelAmount);
+
+    if (ai) {
+      ai.remainingBalance = (ai.remainingBalance ?? 0) + cancelAmount;
+
+      // After cancelling, refundStatus only resets to UNSETTLED if no prior refund
+      // remains in flight or completed (i.e. balance restored to totalPrice).
+      // Otherwise the previously-settled portion of the refund history stays SETTLED.
+      if (ai.remainingBalance >= this.totalPrice) {
+        ai.refundStatus = NewebPayCreditCardBalanceStatus.UNSETTLED;
+        this._state = OrderState.COMMITTED;
+      } else {
+        ai.refundStatus = NewebPayCreditCardBalanceStatus.SETTLED;
+        // _state stays REFUNDED — there's still a settled refund on the order
+      }
+    } else {
+      this._state = OrderState.COMMITTED;
+    }
   }
 
   async refund(amount?: number): Promise<void> {
@@ -262,6 +280,10 @@ export class NewebPayOrder<OCM extends NewebPayCommitMessage = NewebPayCommitMes
     }
 
     const closeStatus = additionalInfo?.closeStatus;
+
+    if (closeStatus === undefined) {
+      throw new Error('Order closeStatus unknown — call query() first');
+    }
 
     if (
       amount !== undefined &&
@@ -296,7 +318,7 @@ export class NewebPayOrder<OCM extends NewebPayCommitMessage = NewebPayCommitMes
       case NewebPayCreditCardBalanceStatus.SETTLED: {
         const refundAmount = amount ?? remainingBalance;
 
-        await this._gateway.refund(this as NewebPayOrder<NewebPayCreditCardCommitMessage>, amount);
+        await this._gateway.refund(this as NewebPayOrder<NewebPayCreditCardCommitMessage>, refundAmount);
 
         const ai = this
           .additionalInfo as AdditionalInfo<NewebPayCreditCardCommitMessage> as NewebPayAdditionInfoCreditCard;

--- a/packages/payments-adapter-newebpay/src/newebpay-order.ts
+++ b/packages/payments-adapter-newebpay/src/newebpay-order.ts
@@ -243,7 +243,17 @@ export class NewebPayOrder<OCM extends NewebPayCommitMessage = NewebPayCommitMes
   }
 
   async refund(amount?: number): Promise<void> {
-    if (this._state !== OrderState.COMMITTED) {
+    const additionalInfo = this.additionalInfo as AdditionalInfo<NewebPayCreditCardCommitMessage> | undefined as
+      | NewebPayAdditionInfoCreditCard
+      | undefined;
+
+    const remainingBalance = additionalInfo?.remainingBalance ?? this.totalPrice;
+
+    // Allow OrderState.REFUNDED only when there's still refundable balance —
+    // NewebPay's QueryTradeInfo maps any prior refund (BackStatus !== UNSETTLED) to
+    // OrderStatusFromAPI.REFUNDED, so a partially-refunded order has state=REFUNDED
+    // even though further partial refunds are still permitted.
+    if (this._state !== OrderState.COMMITTED && !(this._state === OrderState.REFUNDED && remainingBalance > 0)) {
       throw new Error('Only committed order can be refunded');
     }
 
@@ -251,9 +261,7 @@ export class NewebPayOrder<OCM extends NewebPayCommitMessage = NewebPayCommitMes
       throw new Error('Only credit card order can be refunded');
     }
 
-    const closeStatus = (
-      this.additionalInfo as AdditionalInfo<NewebPayCreditCardCommitMessage> as NewebPayAdditionInfoCreditCard
-    ).closeStatus;
+    const closeStatus = additionalInfo?.closeStatus;
 
     if (
       amount !== undefined &&
@@ -285,19 +293,21 @@ export class NewebPayOrder<OCM extends NewebPayCommitMessage = NewebPayCommitMes
         break;
 
       case NewebPayCreditCardBalanceStatus.WORKING:
-      case NewebPayCreditCardBalanceStatus.SETTLED:
+      case NewebPayCreditCardBalanceStatus.SETTLED: {
+        const refundAmount = amount ?? remainingBalance;
+
         await this._gateway.refund(this as NewebPayOrder<NewebPayCreditCardCommitMessage>, amount);
 
-        (
-          this.additionalInfo as AdditionalInfo<NewebPayCreditCardCommitMessage> as NewebPayAdditionInfoCreditCard
-        ).closeStatus = NewebPayCreditCardBalanceStatus.SETTLED;
+        const ai = this
+          .additionalInfo as AdditionalInfo<NewebPayCreditCardCommitMessage> as NewebPayAdditionInfoCreditCard;
 
-        (
-          this.additionalInfo as AdditionalInfo<NewebPayCreditCardCommitMessage> as NewebPayAdditionInfoCreditCard
-        ).refundStatus = NewebPayCreditCardBalanceStatus.WAITING;
+        ai.closeStatus = NewebPayCreditCardBalanceStatus.SETTLED;
+        ai.refundStatus = NewebPayCreditCardBalanceStatus.WAITING;
+        ai.remainingBalance = remainingBalance - refundAmount;
 
         this._state = OrderState.REFUNDED;
         break;
+      }
     }
   }
 }

--- a/packages/payments-adapter-newebpay/src/newebpay-payment.ts
+++ b/packages/payments-adapter-newebpay/src/newebpay-payment.ts
@@ -927,6 +927,18 @@ export class NewebPayPayment<CM extends NewebPayCommitMessage = NewebPayCommitMe
       if (amount > remainingBalance) {
         throw new Error('Refund amount cannot exceed remaining refundable balance');
       }
+
+      // NewebPay manual NDNF-1.1.9 §4.5: installments / bonus-discount transactions
+      // only allow full-amount refund (gateway returns TRA10675 otherwise).
+      if (amount < remainingBalance) {
+        if (additionalInfo.installments) {
+          throw new Error('Partial refund not supported for installment payments');
+        }
+
+        if (additionalInfo.bonusAmount && additionalInfo.bonusAmount > 0) {
+          throw new Error('Partial refund not supported for bonus-discount payments');
+        }
+      }
     }
 
     const refundAmount = amount ?? remainingBalance;
@@ -995,6 +1007,18 @@ export class NewebPayPayment<CM extends NewebPayCommitMessage = NewebPayCommitMe
 
       if (amount > refundedSoFar) {
         throw new Error('Cancel refund amount cannot exceed refunded amount');
+      }
+
+      // Mirror the partial-refund restriction in §4.5: installments / bonus-discount
+      // transactions must cancel the refund in full (gateway returns TRA10675 otherwise).
+      if (amount < refundedSoFar) {
+        if (additionalInfo.installments) {
+          throw new Error('Partial cancel refund not supported for installment payments');
+        }
+
+        if (additionalInfo.bonusAmount && additionalInfo.bonusAmount > 0) {
+          throw new Error('Partial cancel refund not supported for bonus-discount payments');
+        }
       }
     }
 

--- a/packages/payments-adapter-newebpay/src/newebpay-payment.ts
+++ b/packages/payments-adapter-newebpay/src/newebpay-payment.ts
@@ -892,7 +892,7 @@ export class NewebPayPayment<CM extends NewebPayCommitMessage = NewebPayCommitMe
     }
   }
 
-  async refund(order: NewebPayOrder<NewebPayCreditCardCommitMessage>): Promise<void> {
+  async refund(order: NewebPayOrder<NewebPayCreditCardCommitMessage>, amount?: number): Promise<void> {
     if (
       !~[NewebPayCreditCardBalanceStatus.WORKING, NewebPayCreditCardBalanceStatus.SETTLED].indexOf(
         (order.additionalInfo as NewebPayAdditionInfoCreditCard).closeStatus,
@@ -908,13 +908,25 @@ export class NewebPayPayment<CM extends NewebPayCommitMessage = NewebPayCommitMe
       throw new Error('Order refunding.');
     }
 
+    if (amount !== undefined) {
+      if (!Number.isInteger(amount) || amount <= 0) {
+        throw new Error('Refund amount must be a positive integer');
+      }
+
+      if (amount > order.totalPrice) {
+        throw new Error('Refund amount cannot exceed order total price');
+      }
+    }
+
+    const refundAmount = amount ?? order.totalPrice;
+
     const cipher = createCipheriv('aes-256-cbc', this.aesKey, this.aesIv);
 
     const encrypted = `${cipher.update(
       Object.entries({
         RespondType: 'JSON',
         Version: '1.0',
-        Amt: order.totalPrice,
+        Amt: refundAmount,
         MerchantOrderNo: order.id,
         IndexType: 1,
         TimeStamp: Math.round(Date.now() / 1000).toString(),
@@ -944,7 +956,7 @@ export class NewebPayPayment<CM extends NewebPayCommitMessage = NewebPayCommitMe
     }
   }
 
-  async cancelRefund(order: NewebPayOrder<NewebPayCreditCardCommitMessage>): Promise<void> {
+  async cancelRefund(order: NewebPayOrder<NewebPayCreditCardCommitMessage>, amount?: number): Promise<void> {
     if (
       (order.additionalInfo as NewebPayAdditionInfoCreditCard).closeStatus !== NewebPayCreditCardBalanceStatus.SETTLED
     ) {
@@ -961,13 +973,25 @@ export class NewebPayPayment<CM extends NewebPayCommitMessage = NewebPayCommitMe
       throw new Error('Only refunded order can be cancel refund');
     }
 
+    if (amount !== undefined) {
+      if (!Number.isInteger(amount) || amount <= 0) {
+        throw new Error('Cancel refund amount must be a positive integer');
+      }
+
+      if (amount > order.totalPrice) {
+        throw new Error('Cancel refund amount cannot exceed order total price');
+      }
+    }
+
+    const cancelAmount = amount ?? order.totalPrice;
+
     const cipher = createCipheriv('aes-256-cbc', this.aesKey, this.aesIv);
 
     const encrypted = `${cipher.update(
       Object.entries({
         RespondType: 'JSON',
         Version: '1.0',
-        Amt: order.totalPrice,
+        Amt: cancelAmount,
         MerchantOrderNo: order.id,
         IndexType: 1,
         TimeStamp: Math.round(Date.now() / 1000).toString(),

--- a/packages/payments-adapter-newebpay/src/newebpay-payment.ts
+++ b/packages/payments-adapter-newebpay/src/newebpay-payment.ts
@@ -968,15 +968,13 @@ export class NewebPayPayment<CM extends NewebPayCommitMessage = NewebPayCommitMe
   }
 
   async cancelRefund(order: NewebPayOrder<NewebPayCreditCardCommitMessage>, amount?: number): Promise<void> {
-    if (
-      (order.additionalInfo as NewebPayAdditionInfoCreditCard).closeStatus !== NewebPayCreditCardBalanceStatus.SETTLED
-    ) {
+    const additionalInfo = order.additionalInfo as NewebPayAdditionInfoCreditCard;
+
+    if (additionalInfo.closeStatus !== NewebPayCreditCardBalanceStatus.SETTLED) {
       throw new Error('Only settled order can be cancel refund');
     }
 
-    if (
-      (order.additionalInfo as NewebPayAdditionInfoCreditCard).refundStatus !== NewebPayCreditCardBalanceStatus.WAITING
-    ) {
+    if (additionalInfo.refundStatus !== NewebPayCreditCardBalanceStatus.WAITING) {
       throw new Error('Order not refunding.');
     }
 
@@ -984,17 +982,23 @@ export class NewebPayPayment<CM extends NewebPayCommitMessage = NewebPayCommitMe
       throw new Error('Only refunded order can be cancel refund');
     }
 
+    // Cap at refunded-so-far (totalPrice minus any remaining refundable balance).
+    // We can't distinguish pending from settled refund portions from the SDK side,
+    // so this is a permissive but conservative bound — NewebPay's Close API will
+    // reject if the amount doesn't match the actual pending refund.
+    const refundedSoFar = order.totalPrice - (additionalInfo.remainingBalance ?? order.totalPrice);
+
     if (amount !== undefined) {
       if (!Number.isInteger(amount) || amount <= 0) {
         throw new Error('Cancel refund amount must be a positive integer');
       }
 
-      if (amount > order.totalPrice) {
-        throw new Error('Cancel refund amount cannot exceed order total price');
+      if (amount > refundedSoFar) {
+        throw new Error('Cancel refund amount cannot exceed refunded amount');
       }
     }
 
-    const cancelAmount = amount ?? order.totalPrice;
+    const cancelAmount = amount ?? refundedSoFar;
 
     const cipher = createCipheriv('aes-256-cbc', this.aesKey, this.aesIv);
 

--- a/packages/payments-adapter-newebpay/src/newebpay-payment.ts
+++ b/packages/payments-adapter-newebpay/src/newebpay-payment.ts
@@ -711,6 +711,7 @@ export class NewebPayPayment<CM extends NewebPayCommitMessage = NewebPayCommitMe
                 eachAmount: data.Result.InstEach,
               }
             : undefined,
+          bonusAmount: (savedOrder?.additionalInfo as NewebPayAdditionInfoCreditCard | undefined)?.bonusAmount,
           closeStatus: data.Result.CloseStatus,
           closeBalance: Number(data.Result.CloseAmt),
           refundStatus: data.Result.BackStatus,

--- a/packages/payments-adapter-newebpay/src/newebpay-payment.ts
+++ b/packages/payments-adapter-newebpay/src/newebpay-payment.ts
@@ -936,7 +936,7 @@ export class NewebPayPayment<CM extends NewebPayCommitMessage = NewebPayCommitMe
           throw new Error('Partial refund not supported for installment payments');
         }
 
-        if (additionalInfo.bonusAmount && additionalInfo.bonusAmount > 0) {
+        if ((additionalInfo.bonusAmount ?? 0) > 0) {
           throw new Error('Partial refund not supported for bonus-discount payments');
         }
       }
@@ -1018,7 +1018,7 @@ export class NewebPayPayment<CM extends NewebPayCommitMessage = NewebPayCommitMe
           throw new Error('Partial cancel refund not supported for installment payments');
         }
 
-        if (additionalInfo.bonusAmount && additionalInfo.bonusAmount > 0) {
+        if ((additionalInfo.bonusAmount ?? 0) > 0) {
           throw new Error('Partial cancel refund not supported for bonus-discount payments');
         }
       }

--- a/packages/payments-adapter-newebpay/src/newebpay-payment.ts
+++ b/packages/payments-adapter-newebpay/src/newebpay-payment.ts
@@ -995,10 +995,10 @@ export class NewebPayPayment<CM extends NewebPayCommitMessage = NewebPayCommitMe
     }
 
     // Cap at refunded-so-far (totalPrice minus any remaining refundable balance).
-    // We can't distinguish pending from settled refund portions from the SDK side,
-    // so this is a permissive but conservative bound — NewebPay's Close API will
-    // reject if the amount doesn't match the actual pending refund.
+    // When the same order instance initiated the refund, prefer that pending amount;
+    // otherwise the SDK can only compute a conservative cumulative bound.
     const refundedSoFar = order.totalPrice - (additionalInfo.remainingBalance ?? order.totalPrice);
+    const pendingRefundAmount = order.pendingRefundAmount;
 
     if (amount !== undefined) {
       if (!Number.isInteger(amount) || amount <= 0) {
@@ -1022,7 +1022,7 @@ export class NewebPayPayment<CM extends NewebPayCommitMessage = NewebPayCommitMe
       }
     }
 
-    const cancelAmount = amount ?? refundedSoFar;
+    const cancelAmount = amount ?? pendingRefundAmount ?? refundedSoFar;
 
     const cipher = createCipheriv('aes-256-cbc', this.aesKey, this.aesIv);
 

--- a/packages/payments-adapter-newebpay/src/newebpay-payment.ts
+++ b/packages/payments-adapter-newebpay/src/newebpay-payment.ts
@@ -999,13 +999,14 @@ export class NewebPayPayment<CM extends NewebPayCommitMessage = NewebPayCommitMe
     // otherwise the SDK can only compute a conservative cumulative bound.
     const refundedSoFar = order.totalPrice - (additionalInfo.remainingBalance ?? order.totalPrice);
     const pendingRefundAmount = order.pendingRefundAmount;
+    const cancelRefundLimit = pendingRefundAmount ?? refundedSoFar;
 
     if (amount !== undefined) {
       if (!Number.isInteger(amount) || amount <= 0) {
         throw new Error('Cancel refund amount must be a positive integer');
       }
 
-      if (amount > refundedSoFar) {
+      if (amount > cancelRefundLimit) {
         throw new Error('Cancel refund amount cannot exceed refunded amount');
       }
 

--- a/packages/payments-adapter-newebpay/src/newebpay-payment.ts
+++ b/packages/payments-adapter-newebpay/src/newebpay-payment.ts
@@ -893,19 +893,30 @@ export class NewebPayPayment<CM extends NewebPayCommitMessage = NewebPayCommitMe
   }
 
   async refund(order: NewebPayOrder<NewebPayCreditCardCommitMessage>, amount?: number): Promise<void> {
+    const additionalInfo = order.additionalInfo as NewebPayAdditionInfoCreditCard;
+
     if (
       !~[NewebPayCreditCardBalanceStatus.WORKING, NewebPayCreditCardBalanceStatus.SETTLED].indexOf(
-        (order.additionalInfo as NewebPayAdditionInfoCreditCard).closeStatus,
+        additionalInfo.closeStatus,
       )
     ) {
       throw new Error('Only working/settled order can be refunded');
     }
 
+    // A refund is only blocked when one is in flight (WAITING/WORKING). After a previous
+    // partial refund completes (SETTLED), further refunds are allowed as long as the
+    // remaining refundable balance (BackBalance) > 0.
     if (
-      (order.additionalInfo as NewebPayAdditionInfoCreditCard).refundStatus !==
-      NewebPayCreditCardBalanceStatus.UNSETTLED
+      additionalInfo.refundStatus === NewebPayCreditCardBalanceStatus.WAITING ||
+      additionalInfo.refundStatus === NewebPayCreditCardBalanceStatus.WORKING
     ) {
       throw new Error('Order refunding.');
+    }
+
+    const remainingBalance = additionalInfo.remainingBalance ?? order.totalPrice;
+
+    if (remainingBalance <= 0) {
+      throw new Error('Order has no remaining refundable balance');
     }
 
     if (amount !== undefined) {
@@ -913,12 +924,12 @@ export class NewebPayPayment<CM extends NewebPayCommitMessage = NewebPayCommitMe
         throw new Error('Refund amount must be a positive integer');
       }
 
-      if (amount > order.totalPrice) {
-        throw new Error('Refund amount cannot exceed order total price');
+      if (amount > remainingBalance) {
+        throw new Error('Refund amount cannot exceed remaining refundable balance');
       }
     }
 
-    const refundAmount = amount ?? order.totalPrice;
+    const refundAmount = amount ?? remainingBalance;
 
     const cipher = createCipheriv('aes-256-cbc', this.aesKey, this.aesIv);
 


### PR DESCRIPTION
## Summary

Adds an optional `amount?: number` parameter to `NewebPayPayment.refund()` / `cancelRefund()` (and the corresponding `NewebPayOrder.refund()` / `cancelRefund()`) so callers can refund a partial amount of a credit-card order. NewebPay's `CloseType=2` endpoint already supports partial refunds for one-off credit cards / 三大 Pay / 國外卡 (per their MPG NDNF-1.1.9 spec), but the adapter was hard-coding `Amt: order.totalPrice`, forcing every refund to be full.

## Behavior

- `refund(order)` / `cancelRefund(order)` — unchanged, still uses `order.totalPrice` (full refund)
- `refund(order, amount)` / `cancelRefund(order, amount)` — refunds `amount` instead
- Validates: `amount` must be a positive integer not exceeding `order.totalPrice`
- `NewebPayOrder.refund(amount)` only allows partial when `closeStatus` is `WORKING` or `SETTLED` — the cancel-authorization (`NPA-B01`) and unsettle (`CloseType=1, Cancel=1`) paths are integer-amount-only per NewebPay's spec, so an explicit amount on those is rejected with a clear error

## Sub-channel restrictions (NDNF-1.1.9 §4.5)

The NewebPay manual restricts partial refund by sub-channel. The SDK now rejects partial refund / cancel-refund on the client side for the restricted ones to avoid round-tripping a `TRA10675` from the gateway:

| Sub-channel | Partial refund | Manual ref | SDK guard |
|---|---|---|---|
| 一次付清 / 三大 Pay (Apple/Google/Samsung) / 國外卡 | ✅ allowed | §4.5 line 2516-2517 | none (default) |
| 分期付款 (`additionalInfo.installments` set) | ❌ full only | §4.5 line 2518-2519 | `Partial refund not supported for installment payments` |
| 紅利折抵 (`additionalInfo.bonusAmount > 0`) | ❌ full only | §4.5 line 2518-2519 / TRA10675 | `Partial refund not supported for bonus-discount payments` |
| 銀聯卡 (`UNIONPAY`) | ✅ refund partial OK (close full only) | §4.5 line 2520-2521 | none (refund partial allowed) |
| DCC | not restricted for refund (only for close, TRA10058) | §4.5 line 3181 | none |

The same guard is applied symmetrically on `cancelRefund(amount?)` — without it, a full-amount refund on an installment order followed by a partial cancel-refund would slip past the SDK and only fail at the gateway.

`refund()` (no amount) on these channels still works for full refunds.

## Backward compatibility

- All public method signatures only **add** an optional parameter — existing callers compile and behave identically
- The new validation throws only when the caller provides `amount`, so no existing call paths are affected
- The abstract `Order.refund(amount?, options?)` declaration in `@rytass/payments` already had `amount?` — this PR brings the NewebPay implementation in line with that interface
- No other adapter (CTBC / iCash / HappyCard) is touched

## Sandbox e2e verification

Verified against `https://ccore.newebpay.com` with a test merchant + `4000-2211-1111-1111`:

| step | API | result |
|---|---|---|
| commit | MPG/mpg_gateway | `Status=SUCCESS` |
| settle | `CloseType=1` | `Status=SUCCESS`, `CloseStatus 0→3` |
| **partial refund** | **`CloseType=2 Amt=40` (of 100)** | **`Status=SUCCESS`, `BackBalance 100→60`** |
| cancelRefund | `CloseType=2 Cancel=1 Amt=40` | `TRA10094` (sandbox refund completes immediately so cancel window doesn't apply — call structure verified, semantic biz error not HTTP/signature error) |

## Test plan

- [x] `nx test payments-adapter-newebpay` — 110/110 (existing refund cases preserved + new partial-refund / round-trip / sub-channel guard cases)
- [x] `nx lint payments-adapter-newebpay`
- [x] `nx build payments-adapter-newebpay`
- [x] Real-API e2e against NewebPay sandbox (results above)
