### PR TITLE
feat(payments-adapter-ecpay): add ECPayTicketGateway for ECTicket APIs

### DIFF
--- a/packages/payments-adapter-ecpay/README.md
+++ b/packages/payments-adapter-ecpay/README.md
@@ -274,3 +274,73 @@ Default callback paths (overridable via `refundNotifyPath` / `useStatusNotifyPat
 - `POST /payments/ecpay/ticket/use-status`
 
 Each callback is verified against its `CheckMacValue` before the event fires; invalid envelopes are rejected with `400 0|InvalidCheckMacValue` and do not emit.
+
+### Receiving Callbacks Without the Built-in Server
+
+If you already run an HTTP framework (Express, NestJS, Fastify, etc.) and prefer it to receive the notifications, pass the parsed JSON envelope to `handleRefundNotification()` / `handleUseStatusNotification()`. Both verify `CheckMacValue`, decrypt `Data`, emit the corresponding event, and return the typed notification. They throw `ECPayTicketCallbackError` on invalid envelopes.
+
+```typescript
+import {
+  ECPayTicketGateway,
+  ECPayTicketCallbackError,
+  ECPayTicketResponseEnvelope,
+} from '@rytass/payments-adapter-ecpay';
+
+const ticket = new ECPayTicketGateway({
+  merchantId: process.env.ECPAY_MERCHANT_ID!,
+  hashKey: process.env.ECPAY_HASH_KEY!,
+  hashIv: process.env.ECPAY_HASH_IV!,
+  // No withServer — your framework handles HTTP
+});
+
+// Pass these URLs to ECPay via the issue() input
+const refundNotifyUrl = 'https://your-app.com/ecpay/ticket/refund';
+const useStatusNotifyUrl = 'https://your-app.com/ecpay/ticket/use-status';
+
+// === Express ===
+import express from 'express';
+const app = express();
+
+app.post('/ecpay/ticket/refund', express.json(), (req, res) => {
+  try {
+    const notification = ticket.handleRefundNotification(req.body as ECPayTicketResponseEnvelope);
+    // notification is also emitted via ticket.emitter
+    res.type('text/plain').send('1|OK');
+  } catch (err) {
+    if (err instanceof ECPayTicketCallbackError) {
+      res.status(400).type('text/plain').send(`0|${err.code}`);
+      return;
+    }
+    res.status(500).type('text/plain').send('0|InternalError');
+  }
+});
+
+app.post('/ecpay/ticket/use-status', express.json(), (req, res) => {
+  try {
+    ticket.handleUseStatusNotification(req.body as ECPayTicketResponseEnvelope);
+    res.type('text/plain').send('1|OK');
+  } catch (err) {
+    res.status(400).type('text/plain').send('0|Invalid');
+  }
+});
+
+// === NestJS ===
+@Controller('ecpay/ticket')
+export class EcpayTicketController {
+  constructor(@Inject('ECPAY_TICKET') private readonly ticket: ECPayTicketGateway) {}
+
+  @Post('refund')
+  refund(@Body() envelope: ECPayTicketResponseEnvelope): string {
+    this.ticket.handleRefundNotification(envelope);
+    return '1|OK';
+  }
+
+  @Post('use-status')
+  useStatus(@Body() envelope: ECPayTicketResponseEnvelope): string {
+    this.ticket.handleUseStatusNotification(envelope);
+    return '1|OK';
+  }
+}
+```
+
+The event listeners registered on `ticket.emitter` fire identically regardless of whether the notification arrived via the built-in server or via these framework-agnostic handlers — pick whichever transport fits your stack.

--- a/packages/payments-adapter-ecpay/README.md
+++ b/packages/payments-adapter-ecpay/README.md
@@ -158,6 +158,10 @@ const ticket = new ECPayTicketGateway({
     intervalMs: 30_000, // default 30s
     timeoutMs: 6 * 60_000, // default 6min (ECPay claims completion within 5min)
   },
+  // Or disable background polling entirely:
+  // issuePoll: false,   // issue() will not emit TICKET_ISSUED / TICKET_ISSUE_FAILED;
+                       // you are expected to call queryIssueResult() yourself.
+                       // `waitForIssuance: true` still works on a per-call basis.
 });
 
 ticket.emitter.on(ECPayTicketEvents.SERVER_LISTENED, ({ url }) => {
@@ -324,23 +328,164 @@ app.post('/ecpay/ticket/use-status', express.json(), (req, res) => {
   }
 });
 
-// === NestJS ===
+```
+
+The event listeners registered on `ticket.emitter` fire identically regardless of whether the notification arrived via the built-in server or via these framework-agnostic handlers — pick whichever transport fits your stack.
+
+#### NestJS Integration
+
+A complete NestJS setup splits the concerns into three pieces: a module that constructs the gateway from `ConfigService`, a controller that turns ECPay's POSTs into typed events, and a service that subscribes to those events on startup. None of them depend on Node's raw `http` types.
+
+```typescript
+// ecpay-ticket.constants.ts
+export const ECPAY_TICKET_GATEWAY = Symbol('ECPAY_TICKET_GATEWAY');
+```
+
+```typescript
+// ecpay-ticket.module.ts
+import { Module } from '@nestjs/common';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import { ECPayTicketBaseUrls, ECPayTicketGateway } from '@rytass/payments-adapter-ecpay';
+import { ECPAY_TICKET_GATEWAY } from './ecpay-ticket.constants';
+import { EcpayTicketController } from './ecpay-ticket.controller';
+import { EcpayTicketEventService } from './ecpay-ticket-event.service';
+
+@Module({
+  imports: [ConfigModule],
+  providers: [
+    {
+      provide: ECPAY_TICKET_GATEWAY,
+      useFactory: (config: ConfigService): ECPayTicketGateway =>
+        new ECPayTicketGateway({
+          merchantId: config.getOrThrow<string>('ECPAY_MERCHANT_ID'),
+          hashKey: config.getOrThrow<string>('ECPAY_HASH_KEY'),
+          hashIv: config.getOrThrow<string>('ECPAY_HASH_IV'),
+          baseUrl:
+            config.get<string>('NODE_ENV') === 'production'
+              ? ECPayTicketBaseUrls.PRODUCTION
+              : ECPayTicketBaseUrls.DEVELOPMENT,
+          // Do NOT enable the built-in server — Nest's HTTP layer receives the callbacks.
+        }),
+      inject: [ConfigService],
+    },
+    EcpayTicketEventService,
+  ],
+  controllers: [EcpayTicketController],
+  exports: [ECPAY_TICKET_GATEWAY],
+})
+export class EcpayTicketModule {}
+```
+
+```typescript
+// ecpay-ticket.controller.ts
+import {
+  Body,
+  Controller,
+  Header,
+  HttpCode,
+  HttpException,
+  HttpStatus,
+  Inject,
+  Logger,
+  Post,
+} from '@nestjs/common';
+import {
+  ECPayTicketCallbackError,
+  ECPayTicketGateway,
+  ECPayTicketResponseEnvelope,
+} from '@rytass/payments-adapter-ecpay';
+import { ECPAY_TICKET_GATEWAY } from './ecpay-ticket.constants';
+
 @Controller('ecpay/ticket')
 export class EcpayTicketController {
-  constructor(@Inject('ECPAY_TICKET') private readonly ticket: ECPayTicketGateway) {}
+  private readonly logger = new Logger(EcpayTicketController.name);
+
+  constructor(@Inject(ECPAY_TICKET_GATEWAY) private readonly ticket: ECPayTicketGateway) {}
 
   @Post('refund')
-  refund(@Body() envelope: ECPayTicketResponseEnvelope): string {
-    this.ticket.handleRefundNotification(envelope);
-    return '1|OK';
+  @HttpCode(HttpStatus.OK)
+  @Header('Content-Type', 'text/plain')
+  handleRefund(@Body() envelope: ECPayTicketResponseEnvelope): string {
+    try {
+      const notification = this.ticket.handleRefundNotification(envelope);
+
+      this.logger.log(`Refund accepted: ${notification.ticketTradeNo}`);
+
+      return '1|OK';
+    } catch (err) {
+      return this.toErrorResponse(err, 'refund');
+    }
   }
 
   @Post('use-status')
-  useStatus(@Body() envelope: ECPayTicketResponseEnvelope): string {
-    this.ticket.handleUseStatusNotification(envelope);
-    return '1|OK';
+  @HttpCode(HttpStatus.OK)
+  @Header('Content-Type', 'text/plain')
+  handleUseStatus(@Body() envelope: ECPayTicketResponseEnvelope): string {
+    try {
+      const notification = this.ticket.handleUseStatusNotification(envelope);
+
+      this.logger.log(`Use status: ${notification.ticketNo} → ${notification.useStatus}`);
+
+      return '1|OK';
+    } catch (err) {
+      return this.toErrorResponse(err, 'use-status');
+    }
+  }
+
+  private toErrorResponse(err: unknown, scope: string): never {
+    if (err instanceof ECPayTicketCallbackError) {
+      this.logger.warn(`Rejected ${scope} callback: ${err.code}`);
+      throw new HttpException(
+        `0|${err.code === 'INVALID_CHECKMAC' ? 'InvalidCheckMacValue' : 'InvalidData'}`,
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+
+    this.logger.error(`Unexpected ${scope} callback error`, err);
+    throw new HttpException('0|InternalError', HttpStatus.INTERNAL_SERVER_ERROR);
   }
 }
 ```
 
-The event listeners registered on `ticket.emitter` fire identically regardless of whether the notification arrived via the built-in server or via these framework-agnostic handlers — pick whichever transport fits your stack.
+```typescript
+// ecpay-ticket-event.service.ts
+import { Inject, Injectable, Logger, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
+import {
+  ECPayTicketEvents,
+  ECPayTicketGateway,
+  ECPayTicketRefundNotification,
+  ECPayTicketUseStatusNotification,
+} from '@rytass/payments-adapter-ecpay';
+import { ECPAY_TICKET_GATEWAY } from './ecpay-ticket.constants';
+
+@Injectable()
+export class EcpayTicketEventService implements OnModuleInit, OnModuleDestroy {
+  private readonly logger = new Logger(EcpayTicketEventService.name);
+
+  private readonly onRefund = (n: ECPayTicketRefundNotification): void => {
+    // Persist refund, notify customer, etc.
+    this.logger.log(`Refund received: ${n.ticketTradeNo} amount=${n.refundAmount}`);
+  };
+
+  private readonly onUseStatus = (n: ECPayTicketUseStatusNotification): void => {
+    // Update ticket usage state in your DB
+    this.logger.log(`Ticket ${n.ticketNo} → ${n.useStatus}`);
+  };
+
+  constructor(@Inject(ECPAY_TICKET_GATEWAY) private readonly ticket: ECPayTicketGateway) {}
+
+  onModuleInit(): void {
+    this.ticket.emitter.on(ECPayTicketEvents.TICKET_REFUND_NOTIFIED, this.onRefund);
+    this.ticket.emitter.on(ECPayTicketEvents.TICKET_USE_STATUS_CHANGED, this.onUseStatus);
+  }
+
+  onModuleDestroy(): void {
+    this.ticket.emitter.off(ECPayTicketEvents.TICKET_REFUND_NOTIFIED, this.onRefund);
+    this.ticket.emitter.off(ECPayTicketEvents.TICKET_USE_STATUS_CHANGED, this.onUseStatus);
+  }
+}
+```
+
+**Wiring the notify URLs.** When you call `ticket.issue()`, pass `refundNotifyUrl` and `useStatusNotifyUrl` pointing at the Nest controller routes (e.g. `https://your-domain.com/ecpay/ticket/refund`). Nest's `@Body()` decorator parses the JSON for you, so the controller methods receive the typed envelope directly — no body-parser boilerplate.
+
+**Why `OnModuleDestroy`.** The event listeners are bound in `onModuleInit` and explicitly removed in `onModuleDestroy` so reloading the module (e.g. in tests or with HMR) does not leak duplicate listeners on the long-lived gateway emitter.

--- a/packages/payments-adapter-ecpay/README.md
+++ b/packages/payments-adapter-ecpay/README.md
@@ -15,6 +15,9 @@
 - [ ] Refund
 - [ ] Refund (Installments)
 - [x] Card Binding
+- [x] Ticket Issue (ECTicket)
+- [x] Query Ticket Issue Result
+- [x] Query Ticket Order Info
 
 ## Getting Started
 
@@ -123,3 +126,151 @@ payment.emitter.on(PaymentEvents.CARD_BINDING_FAILED, (request: ECPayBindCardReq
   }
 });
 ```
+
+## ECTicket (票券) APIs
+
+`ECPayTicketGateway` is an independent gateway for the ECPay ECTicket product line (issuing, querying, refund/redeem notifications for redemption and gift tickets). It uses a different base URL (`ecticket.ecpay.com.tw`) and wire format (AES-128-CBC encrypted JSON envelope with a `CheckMacValue`) than `ECPayPayment`, so it is exposed as a separate class. It shares the same HashKey / HashIV credentials with the payment gateway.
+
+### Setup
+
+```typescript
+import {
+  ECPayTicketGateway,
+  ECPayTicketBaseUrls,
+  ECPayTicketEvents,
+  ECPayIssueType,
+  ECPayPrintType,
+  ECPayIsImmediate,
+} from '@rytass/payments-adapter-ecpay';
+
+const ticket = new ECPayTicketGateway({
+  merchantId: process.env.ECPAY_MERCHANT_ID!,
+  hashKey: process.env.ECPAY_HASH_KEY!,
+  hashIv: process.env.ECPAY_HASH_IV!,
+  baseUrl: ECPayTicketBaseUrls.PRODUCTION, // omit for staging
+
+  // Optional: built-in callback server for RefundNotifyURL / UseStatusNotifyURL
+  withServer: true,
+  serverHost: 'https://your-domain.com',
+
+  // Optional: tune background polling for issuance result
+  issuePoll: {
+    intervalMs: 30_000, // default 30s
+    timeoutMs: 6 * 60_000, // default 6min (ECPay claims completion within 5min)
+  },
+});
+
+ticket.emitter.on(ECPayTicketEvents.SERVER_LISTENED, ({ url }) => {
+  console.log('Ticket callback server ready at', url);
+});
+```
+
+### Issue Tickets
+
+After ECPay receives the issue request, the actual issuance is processed asynchronously (typically within 5 minutes). Two usage modes are supported:
+
+**Mode A — return receipt immediately, listen for the final result via events:**
+
+```typescript
+ticket.emitter.on(ECPayTicketEvents.TICKET_ISSUED, outcome => {
+  // outcome: { status: 'success', merchantTradeNo, freeTradeNo? }
+  console.log('Issued:', outcome.merchantTradeNo);
+});
+
+ticket.emitter.on(ECPayTicketEvents.TICKET_ISSUE_FAILED, outcome => {
+  // outcome: { status: 'failed', merchantTradeNo, remark }
+  console.error('Issue failed:', outcome.remark);
+});
+
+const receipt = await ticket.issue({
+  merchantTradeNo: 'ORDER-2026-0001',
+  issueType: ECPayIssueType.PAPER, // CVS / PAPER / ELECTRONIC / SERIAL_ONLY
+  printType: ECPayPrintType.ECPAY, // required when issueType is PAPER
+  operator: 'system',
+  customer: {
+    name: '王小明',
+    phone: '0912345678',
+    email: 'buyer@example.com',
+  },
+  tickets: [
+    { itemNo: 'I1', itemName: '咖啡兌換券', ticketPrice: 150, ticketAmount: 10 },
+  ],
+});
+
+console.log(receipt.ticketTradeNo); // ECPay-assigned trade number
+```
+
+**Mode B — await final outcome (`waitForIssuance: true`):**
+
+```typescript
+const outcome = await ticket.issue({
+  merchantTradeNo: 'ORDER-2026-0002',
+  issueType: ECPayIssueType.ELECTRONIC,
+  isImmediate: ECPayIsImmediate.IMMEDIATE,
+  operator: 'system',
+  customer: { name: '王小明', phone: '0912345678', email: 'a@b.com' },
+  tickets: [{ itemNo: 'I1', ticketAmount: 1 }],
+  waitForIssuance: true,
+});
+
+if (outcome.status === 'success') {
+  // proceed with fulfilment
+} else if (outcome.status === 'failed') {
+  console.error(outcome.remark);
+}
+```
+
+### Query Issue Result (manual)
+
+```typescript
+const outcome = await ticket.queryIssueResult({ merchantTradeNo: 'ORDER-2026-0001' });
+
+switch (outcome.status) {
+  case 'success':
+    // tickets are ready
+    break;
+  case 'processing':
+    // still in queue
+    break;
+  case 'failed':
+    console.error(outcome.remark);
+    break;
+}
+```
+
+### Query Order Info (with ticket list)
+
+```typescript
+const info = await ticket.queryOrderInfo({
+  merchantTradeNo: 'ORDER-2026-0001',
+  pageNum: 1, // optional, 200 tickets per page
+});
+
+console.log(info.totalCount, info.tradeAmount);
+console.log(info.redeemCount, info.refundCount, info.unUsedCount);
+
+info.tickets.forEach(t => {
+  console.log(t.ticketNo, t.useStatus); // 'unused' | 'redeemed' | 'refunded' | 'expired'
+});
+```
+
+### Refund / Use-status Notifications
+
+When `withServer: true`, the gateway mounts two callback endpoints and emits events whenever ECPay pushes a notification. Pass the notify URLs to `issue()` either explicitly via `refundNotifyUrl` / `useStatusNotifyUrl`, or let the gateway auto-fill them from `serverHost`.
+
+```typescript
+ticket.emitter.on(ECPayTicketEvents.TICKET_REFUND_NOTIFIED, notification => {
+  console.log('Refunded:', notification.ticketTradeNo, notification.refundAmount);
+});
+
+ticket.emitter.on(ECPayTicketEvents.TICKET_USE_STATUS_CHANGED, notification => {
+  console.log('Use status changed:', notification.ticketNo, notification.useStatus);
+});
+```
+
+Default callback paths (overridable via `refundNotifyPath` / `useStatusNotifyPath` options):
+
+- `POST /payments/ecpay/ticket/refund`
+- `POST /payments/ecpay/ticket/use-status`
+
+Each callback is verified against its `CheckMacValue` before the event fires; invalid envelopes are rejected with `400 0|InvalidCheckMacValue` and do not emit.

--- a/packages/payments-adapter-ecpay/__tests__/ecpay-bind-card.spec.ts
+++ b/packages/payments-adapter-ecpay/__tests__/ecpay-bind-card.spec.ts
@@ -43,6 +43,10 @@ describe('ECPayPayment Card Binding', () => {
     return mockServer;
   });
 
+  afterAll(() => {
+    mockedCreateServer.mockRestore();
+  });
+
   it('should card binding fail', done => {
     const payment = new ECPayPayment({
       withServer: true,
@@ -515,7 +519,7 @@ describe('ECPayPayment Card Binding', () => {
     });
 
     // Call prepareBindCard immediately before server is ready
-    await expect(payment.prepareBindCard('rytass')).rejects.toThrow('Please waiting gateway ready');
+    await expect(payment.prepareBindCard('rytass')).rejects.toThrow(/Gateway is not ready yet/);
 
     // Clean up
     if (payment._server) {

--- a/packages/payments-adapter-ecpay/__tests__/ecpay-order.spec.ts
+++ b/packages/payments-adapter-ecpay/__tests__/ecpay-order.spec.ts
@@ -38,6 +38,10 @@ describe('ECPayOrder', () => {
     return mockServer;
   });
 
+  afterAll(() => {
+    mockedCreateServer.mockRestore();
+  });
+
   const payment = new ECPayPayment();
 
   it('should calculate total price', async () => {

--- a/packages/payments-adapter-ecpay/__tests__/ecpay-payment-apple-pay.spec.ts
+++ b/packages/payments-adapter-ecpay/__tests__/ecpay-payment-apple-pay.spec.ts
@@ -32,6 +32,10 @@ describe('ECPayPayment (Apple Pay)', () => {
     return mockServer;
   });
 
+  afterAll(() => {
+    mockedCreateServer.mockRestore();
+  });
+
   describe('Apple Pay', () => {
     const payment = new ECPayPayment<ECPayChannelApplePay>();
 

--- a/packages/payments-adapter-ecpay/__tests__/ecpay-payment-barcode.spec.ts
+++ b/packages/payments-adapter-ecpay/__tests__/ecpay-payment-barcode.spec.ts
@@ -39,6 +39,10 @@ describe('ECPayPayment (Barcode)', () => {
     return mockServer;
   });
 
+  afterAll(() => {
+    mockedCreateServer.mockRestore();
+  });
+
   describe('Barcode', () => {
     it('should throw on not barcode channel set cvsBarcodeExpireDays', done => {
       const payment = new ECPayPayment<ECPayChannelBarcode>({

--- a/packages/payments-adapter-ecpay/__tests__/ecpay-payment-cvs.spec.ts
+++ b/packages/payments-adapter-ecpay/__tests__/ecpay-payment-cvs.spec.ts
@@ -39,6 +39,10 @@ describe('ECPayPayment (CVS)', () => {
     return mockServer;
   });
 
+  afterAll(() => {
+    mockedCreateServer.mockRestore();
+  });
+
   describe('CVS', () => {
     it('should throw on not cvs channel set cvsExpireMinutes', done => {
       const payment = new ECPayPayment<ECPayChannelCVS>({

--- a/packages/payments-adapter-ecpay/__tests__/ecpay-payment-refund.spec.ts
+++ b/packages/payments-adapter-ecpay/__tests__/ecpay-payment-refund.spec.ts
@@ -68,6 +68,10 @@ describe('ECPayPayment Refund', () => {
     return mockServer;
   });
 
+  afterAll(() => {
+    mockedCreateServer.mockRestore();
+  });
+
   describe('Waiting withServer mode server listen', () => {
     it('should reject credit card trade status getter on server not ready', done => {
       const payment = new ECPayPayment({

--- a/packages/payments-adapter-ecpay/__tests__/ecpay-payment-virtual-account.spec.ts
+++ b/packages/payments-adapter-ecpay/__tests__/ecpay-payment-virtual-account.spec.ts
@@ -46,6 +46,10 @@ describe('ECPayPayment (Virtual Account)', () => {
     return mockServer;
   });
 
+  afterAll(() => {
+    mockedCreateServer.mockRestore();
+  });
+
   describe('Virtual account', () => {
     const payment = new ECPayPayment<ECPayChannelVirtualAccount | ECPayChannelCreditCard>({
       serverHost: 'http://localhost:9999',

--- a/packages/payments-adapter-ecpay/__tests__/ecpay-payment.spec.ts
+++ b/packages/payments-adapter-ecpay/__tests__/ecpay-payment.spec.ts
@@ -47,6 +47,10 @@ describe('ECPayPayment', () => {
     return mockServer;
   });
 
+  afterAll(() => {
+    mockedCreateServer.mockRestore();
+  });
+
   describe('Waiting withServer mode server listen', () => {
     it('should reject prepare on server not ready', done => {
       const payment = new ECPayPayment({

--- a/packages/payments-adapter-ecpay/__tests__/ecpay-query-bind-card-info.spec.ts
+++ b/packages/payments-adapter-ecpay/__tests__/ecpay-query-bind-card-info.spec.ts
@@ -60,6 +60,10 @@ describe('ECPayPayment Query Card Bound Info', () => {
     return mockServer;
   });
 
+  afterAll(() => {
+    mockedCreateServer.mockRestore();
+  });
+
   const post = jest.spyOn(axios, 'post');
 
   const payment = new ECPayPayment({

--- a/packages/payments-adapter-ecpay/__tests__/ecpay-ticket-gateway.spec.ts
+++ b/packages/payments-adapter-ecpay/__tests__/ecpay-ticket-gateway.spec.ts
@@ -213,6 +213,114 @@ describe('ECPayTicketGateway', () => {
       ).rejects.toThrow(/Invalid CheckMacValue/);
     });
 
+    it('with issuePoll: false, does not start background polling after issue()', async () => {
+      const gateway = new ECPayTicketGateway({ issuePoll: false });
+
+      const issueDecrypted: ECPayTicketIssueResponseDecrypted = {
+        RtnCode: 1,
+        RtnMsg: 'OK',
+        MerchantTradeNo: 'M-NO-POLL',
+        TicketTradeNo: 'TT-NO-POLL',
+        TicketData: [],
+      };
+
+      let issueCalls = 0;
+      let queryCalls = 0;
+
+      post.mockImplementation(async (url: string) => {
+        if (url.endsWith('/api/Ticket/Issue')) {
+          issueCalls += 1;
+
+          return { data: buildTicketResponseEnvelope(issueDecrypted) };
+        }
+
+        queryCalls += 1;
+
+        return {
+          data: buildTicketResponseEnvelope<ECPayTicketQueryIssueResultResponseDecrypted>({
+            RtnCode: 1,
+            RtnMsg: 'OK',
+            MerchantTradeNo: 'M-NO-POLL',
+            Status: 3,
+            Remark: '',
+          }),
+        };
+      });
+
+      let issuedFired = false;
+      let issueFailedFired = false;
+
+      gateway.emitter.on(ECPayTicketEvents.TICKET_ISSUED, () => {
+        issuedFired = true;
+      });
+
+      gateway.emitter.on(ECPayTicketEvents.TICKET_ISSUE_FAILED, () => {
+        issueFailedFired = true;
+      });
+
+      await gateway.issue({
+        merchantTradeNo: 'M-NO-POLL',
+        issueType: ECPayIssueType.CVS,
+        operator: 'Tester',
+        tickets: [{ itemNo: 'I1', ticketAmount: 1 }],
+      });
+
+      // Give any (incorrectly-scheduled) timers a chance to run
+      await new Promise(resolve => setTimeout(resolve, 50));
+
+      expect(issueCalls).toBe(1);
+      expect(queryCalls).toBe(0);
+      expect(issuedFired).toBe(false);
+      expect(issueFailedFired).toBe(false);
+    });
+
+    it('issuePoll: false still honours waitForIssuance: true on a per-call basis', async () => {
+      const gateway = new ECPayTicketGateway({
+        issuePoll: false,
+      });
+
+      // Override the default poll interval via private field (waitForIssuance path uses defaults)
+      // For a fast test, the public API doesn't allow tuning when issuePoll:false, so we override via reflection:
+      // @ts-expect-error white-box: shrink the poll interval to keep the test fast
+      gateway.pollIntervalMs = 10;
+      // @ts-expect-error
+      gateway.pollTimeoutMs = 1000;
+
+      const issueDecrypted: ECPayTicketIssueResponseDecrypted = {
+        RtnCode: 1,
+        RtnMsg: 'OK',
+        MerchantTradeNo: 'M-NO-POLL-WAIT',
+        TicketTradeNo: 'TT-NO-POLL-WAIT',
+        TicketData: [],
+      };
+
+      post.mockImplementation(async (url: string) => {
+        if (url.endsWith('/api/Ticket/Issue')) {
+          return { data: buildTicketResponseEnvelope(issueDecrypted) };
+        }
+
+        return {
+          data: buildTicketResponseEnvelope<ECPayTicketQueryIssueResultResponseDecrypted>({
+            RtnCode: 1,
+            RtnMsg: 'OK',
+            MerchantTradeNo: 'M-NO-POLL-WAIT',
+            Status: 1,
+            Remark: '',
+          }),
+        };
+      });
+
+      const outcome = (await gateway.issue({
+        merchantTradeNo: 'M-NO-POLL-WAIT',
+        issueType: ECPayIssueType.CVS,
+        operator: 'Tester',
+        tickets: [{ itemNo: 'I1', ticketAmount: 1 }],
+        waitForIssuance: true,
+      })) as ECPayTicketIssueOutcome;
+
+      expect(outcome.status).toBe('success');
+    });
+
     it('with waitForIssuance=true, resolves with the final outcome after polling', async () => {
       const gateway = new ECPayTicketGateway({
         issuePoll: { intervalMs: 10, timeoutMs: 5_000 },

--- a/packages/payments-adapter-ecpay/__tests__/ecpay-ticket-gateway.spec.ts
+++ b/packages/payments-adapter-ecpay/__tests__/ecpay-ticket-gateway.spec.ts
@@ -46,6 +46,26 @@ describe('ECPayTicketGateway', () => {
     return mockServer;
   });
 
+  afterAll(() => {
+    mockedCreateServer.mockRestore();
+  });
+
+  describe('constructor validation', () => {
+    it('throws when hashKey is not exactly 16 bytes', () => {
+      expect(() => new ECPayTicketGateway({ hashKey: 'tooShort' })).toThrow(/hashKey must be exactly 16 bytes/);
+      expect(() => new ECPayTicketGateway({ hashKey: 'a'.repeat(17) })).toThrow(/hashKey must be exactly 16 bytes/);
+    });
+
+    it('throws when hashIv is not exactly 16 bytes', () => {
+      expect(() => new ECPayTicketGateway({ hashIv: 'tooShort' })).toThrow(/hashIv must be exactly 16 bytes/);
+    });
+
+    it('throws when hashKey contains multibyte characters that exceed 16 bytes', () => {
+      // '中' is 3 bytes in UTF-8; 8 of them = 24 bytes > 16
+      expect(() => new ECPayTicketGateway({ hashKey: '中'.repeat(8) })).toThrow(/hashKey must be exactly 16 bytes/);
+    });
+  });
+
   describe('encrypt/decrypt symmetry', () => {
     it('roundtrip preserves payload exactly', () => {
       const gateway = new ECPayTicketGateway();
@@ -475,6 +495,44 @@ describe('ECPayTicketGateway', () => {
       expect(info.tickets[3].useStatus).toBe(ECPayTicketUseStatus.EXPIRED);
       expect(info.tickets[1].writeOffDate).toBeInstanceOf(Date);
     });
+
+    it('omits date fields when ECPay sends malformed date strings', async () => {
+      const gateway = new ECPayTicketGateway();
+
+      const decrypted: ECPayTicketQueryOrderInfoResponseDecrypted = {
+        RtnCode: 1,
+        RtnMsg: 'OK',
+        MerchantID: '2000132',
+        MerchantTradeNo: 'M-BAD-DATES',
+        TicketTradeNo: 'TT',
+        PaymentProvider: '1',
+        PaymentType: '1',
+        Status: 1,
+        Remark: '',
+        IssueDate: 'not-a-date',
+        IssueType: ECPayIssueType.SERIAL_ONLY,
+        EscrowExpiredDate: 'oops',
+        TotalCount: 1,
+        TradeAmount: 100,
+        RedeemCount: 0,
+        RedeemAmount: 0,
+        RefundCount: 0,
+        RefundAmount: 0,
+        TotalRefundFee: 0,
+        UnUsedCount: 1,
+        UnUsedAmount: 100,
+        ExpiredCount: 0,
+        TicketList: [{ TicketNo: 'TKT-1', UseStatus: 1, TicketType: '1', TicketAmount: 100, StartDate: 'garbage' }],
+      };
+
+      jest.spyOn(axios, 'post').mockImplementation(async () => ({ data: buildTicketResponseEnvelope(decrypted) }));
+
+      const info = await gateway.queryOrderInfo({ merchantTradeNo: 'M-BAD-DATES' });
+
+      expect(info.issueDate).toBeUndefined();
+      expect(info.escrowExpiredDate).toBeUndefined();
+      expect(info.tickets[0].startDate).toBeUndefined();
+    });
   });
 
   describe('built-in callback server', () => {
@@ -657,6 +715,93 @@ describe('ECPayTicketGateway', () => {
       expect(result.ticketNo).toBe('TKT-USE-X');
       expect(result.useStatus).toBe(ECPayTicketUseStatus.REDEEMED);
       expect(emitted).toBe(result);
+    });
+
+    it('handleRefundNotification throws INVALID_PAYLOAD when TicketTradeNo is missing', () => {
+      const gateway = new ECPayTicketGateway();
+
+      const envelope = buildTicketResponseEnvelope({
+        MerchantTradeNo: 'M-X',
+        RefundAmount: 100,
+        // TicketTradeNo intentionally omitted
+      });
+
+      let fired = false;
+
+      gateway.emitter.on(ECPayTicketEvents.TICKET_REFUND_NOTIFIED, () => {
+        fired = true;
+      });
+
+      try {
+        gateway.handleRefundNotification(envelope);
+        throw new Error('expected to throw');
+      } catch (err) {
+        expect(err).toBeInstanceOf(ECPayTicketCallbackError);
+        expect((err as ECPayTicketCallbackError).code).toBe('INVALID_PAYLOAD');
+      }
+
+      expect(fired).toBe(false);
+    });
+
+    it('handleRefundNotification throws INVALID_PAYLOAD when both MerchantTradeNo and FreeTradeNo are absent', () => {
+      const gateway = new ECPayTicketGateway();
+
+      const envelope = buildTicketResponseEnvelope({
+        TicketTradeNo: 'TT-OK',
+        RefundAmount: 50,
+        // No MerchantTradeNo, no FreeTradeNo
+      });
+
+      try {
+        gateway.handleRefundNotification(envelope);
+        throw new Error('expected to throw');
+      } catch (err) {
+        expect((err as ECPayTicketCallbackError).code).toBe('INVALID_PAYLOAD');
+      }
+    });
+
+    it('handleUseStatusNotification throws INVALID_PAYLOAD when UseStatus is missing', () => {
+      const gateway = new ECPayTicketGateway();
+
+      const envelope = buildTicketResponseEnvelope({
+        MerchantTradeNo: 'M-X',
+        TicketTradeNo: 'TT-X',
+        TicketNo: 'TKT-X',
+        // UseStatus intentionally missing — must not default to UNUSED
+      });
+
+      let fired = false;
+
+      gateway.emitter.on(ECPayTicketEvents.TICKET_USE_STATUS_CHANGED, () => {
+        fired = true;
+      });
+
+      try {
+        gateway.handleUseStatusNotification(envelope);
+        throw new Error('expected to throw');
+      } catch (err) {
+        expect((err as ECPayTicketCallbackError).code).toBe('INVALID_PAYLOAD');
+      }
+
+      expect(fired).toBe(false);
+    });
+
+    it('handleUseStatusNotification throws INVALID_PAYLOAD when UseStatus is out of range', () => {
+      const gateway = new ECPayTicketGateway();
+
+      const envelope = buildTicketResponseEnvelope({
+        MerchantTradeNo: 'M-X',
+        TicketTradeNo: 'TT-X',
+        TicketNo: 'TKT-X',
+        UseStatus: 99,
+      });
+
+      try {
+        gateway.handleUseStatusNotification(envelope);
+        throw new Error('expected to throw');
+      } catch (err) {
+        expect((err as ECPayTicketCallbackError).code).toBe('INVALID_PAYLOAD');
+      }
     });
 
     it('handleRefundNotification throws ECPayTicketCallbackError(INVALID_CHECKMAC) on tampered envelope', () => {

--- a/packages/payments-adapter-ecpay/__tests__/ecpay-ticket-gateway.spec.ts
+++ b/packages/payments-adapter-ecpay/__tests__/ecpay-ticket-gateway.spec.ts
@@ -1,0 +1,542 @@
+/**
+ * @jest-environment node
+ */
+
+import axios from 'axios';
+import { AddressInfo } from 'net';
+import http, { createServer } from 'http';
+import {
+  ECPayIssueType,
+  ECPayPrintType,
+  ECPayTicketEvents,
+  ECPayTicketGateway,
+  ECPayTicketIssueOutcome,
+  ECPayTicketRefundNotification,
+  ECPayTicketUseStatus,
+  ECPayTicketUseStatusNotification,
+} from '../src';
+import {
+  ECPayTicketIssueResponseDecrypted,
+  ECPayTicketQueryIssueResultResponseDecrypted,
+  ECPayTicketQueryOrderInfoResponseDecrypted,
+} from '../src/ecpay-ticket-typings';
+import {
+  buildTicketResponseEnvelope,
+  computeTicketCheckMacValue,
+  encryptTicketData,
+} from '../__utils__/ticket-envelope';
+
+describe('ECPayTicketGateway', () => {
+  // 強制 built-in server 綁定到隨機可用 port，避免 3000 被占用或多測試衝突
+  const originCreateServer = createServer;
+  const mockedCreateServer = jest.spyOn(http, 'createServer');
+
+  mockedCreateServer.mockImplementation(requestHandler => {
+    const mockServer = originCreateServer(requestHandler);
+
+    const mockedListen = jest.spyOn(mockServer, 'listen');
+
+    mockedListen.mockImplementationOnce((_port?: number, _hostname?: string, listeningListener?: () => void) => {
+      mockServer.listen(0, listeningListener);
+
+      return mockServer;
+    });
+
+    return mockServer;
+  });
+
+  describe('encrypt/decrypt symmetry', () => {
+    it('roundtrip preserves payload exactly', () => {
+      const gateway = new ECPayTicketGateway();
+      const original = { ItemName: '中文 Name', Amount: 100, Nested: { Foo: 'bar' } };
+      const encrypted = encryptTicketData(original);
+      // @ts-expect-error access private for white-box test
+      const decrypted = gateway.decrypt(encrypted);
+
+      expect(decrypted).toEqual(original);
+    });
+  });
+
+  describe('CheckMacValue calculation', () => {
+    it('produces deterministic SHA256 uppercase output', () => {
+      const macA = computeTicketCheckMacValue('AAAA');
+      const macB = computeTicketCheckMacValue('AAAA');
+
+      expect(macA).toBe(macB);
+      expect(macA).toMatch(/^[0-9A-F]{64}$/);
+    });
+
+    it('changes when Data changes', () => {
+      expect(computeTicketCheckMacValue('AAAA')).not.toBe(computeTicketCheckMacValue('BBBB'));
+    });
+  });
+
+  describe('issue()', () => {
+    let post: jest.SpyInstance;
+
+    beforeEach(() => {
+      post = jest.spyOn(axios, 'post');
+    });
+
+    afterEach(() => {
+      post.mockRestore();
+    });
+
+    it('rejects when no merchantTradeNo / freeTradeNo provided', async () => {
+      const gateway = new ECPayTicketGateway();
+
+      await expect(
+        gateway.issue({
+          issueType: ECPayIssueType.SERIAL_ONLY,
+          operator: 'Test',
+          tickets: [{ ticketAmount: 1, itemName: 'X', ticketPrice: 100 }],
+        }),
+      ).rejects.toThrow(/merchantTradeNo or freeTradeNo/);
+    });
+
+    it('rejects when tickets array empty', async () => {
+      const gateway = new ECPayTicketGateway();
+
+      await expect(
+        gateway.issue({
+          merchantTradeNo: 'M1',
+          issueType: ECPayIssueType.CVS,
+          operator: 'Test',
+          tickets: [],
+        }),
+      ).rejects.toThrow(/At least one ticket/);
+    });
+
+    it('posts a valid encrypted envelope and returns receipt immediately', async () => {
+      const gateway = new ECPayTicketGateway({
+        // 把輪詢調得遠大於這個測試的時間範圍，避免背景輪詢觸發 axios
+        issuePoll: { intervalMs: 60_000, timeoutMs: 60_000 },
+      });
+
+      const decryptedResponse: ECPayTicketIssueResponseDecrypted = {
+        RtnCode: 1,
+        RtnMsg: 'OK',
+        MerchantTradeNo: 'M001',
+        TicketTradeNo: 'TT12345678901234',
+        TicketData: [{ ItemNo: 'I1', TicketAmount: 2 }],
+      };
+
+      post.mockImplementation(async (url: string, body: unknown) => {
+        expect(url).toBe('https://ecticket-stage.ecpay.com.tw/api/Ticket/Issue');
+
+        const parsed = JSON.parse(body as string);
+
+        expect(parsed.MerchantID).toBe('2000132');
+        expect(parsed.RqHeader.Timestamp).toEqual(expect.any(Number));
+        expect(typeof parsed.Data).toBe('string');
+        expect(parsed.CheckMacValue).toBe(computeTicketCheckMacValue(parsed.Data));
+
+        return { data: buildTicketResponseEnvelope(decryptedResponse) };
+      });
+
+      const result = await gateway.issue({
+        merchantTradeNo: 'M001',
+        issueType: ECPayIssueType.CVS,
+        operator: 'Tester',
+        customer: { email: 'a@b.com' },
+        tickets: [{ itemNo: 'I1', ticketAmount: 2 }],
+      });
+
+      expect(result).toMatchObject({
+        merchantTradeNo: 'M001',
+        ticketTradeNo: 'TT12345678901234',
+        tickets: [{ itemNo: 'I1', ticketAmount: 2 }],
+      });
+    });
+
+    it('throws on TransCode != 1', async () => {
+      const gateway = new ECPayTicketGateway();
+
+      post.mockImplementation(async () => ({
+        data: buildTicketResponseEnvelope({ ignored: true }, { transCode: 99, transMsg: 'Bad request' }),
+      }));
+
+      await expect(
+        gateway.issue({
+          merchantTradeNo: 'M001',
+          issueType: ECPayIssueType.CVS,
+          operator: 'Tester',
+          tickets: [{ itemNo: 'I1', ticketAmount: 1 }],
+        }),
+      ).rejects.toThrow(/transport error.*Bad request/);
+    });
+
+    it('throws on Decrypted RtnCode != 1', async () => {
+      const gateway = new ECPayTicketGateway();
+
+      const decrypted: ECPayTicketIssueResponseDecrypted = {
+        RtnCode: 10010,
+        RtnMsg: 'Invalid Operator',
+        TicketTradeNo: '',
+        TicketData: [],
+      };
+
+      post.mockImplementation(async () => ({ data: buildTicketResponseEnvelope(decrypted) }));
+
+      await expect(
+        gateway.issue({
+          merchantTradeNo: 'M001',
+          issueType: ECPayIssueType.CVS,
+          operator: 'BadOp',
+          tickets: [{ itemNo: 'I1', ticketAmount: 1 }],
+        }),
+      ).rejects.toThrow(/issue failed.*Invalid Operator/);
+    });
+
+    it('rejects when response CheckMacValue invalid', async () => {
+      const gateway = new ECPayTicketGateway();
+
+      const envelope = buildTicketResponseEnvelope<ECPayTicketIssueResponseDecrypted>({
+        RtnCode: 1,
+        RtnMsg: 'OK',
+        TicketTradeNo: 'TT',
+        TicketData: [],
+      });
+
+      envelope.CheckMacValue = 'TAMPERED';
+
+      post.mockImplementation(async () => ({ data: envelope }));
+
+      await expect(
+        gateway.issue({
+          merchantTradeNo: 'M001',
+          issueType: ECPayIssueType.CVS,
+          operator: 'Tester',
+          tickets: [{ itemNo: 'I1', ticketAmount: 1 }],
+        }),
+      ).rejects.toThrow(/Invalid CheckMacValue/);
+    });
+
+    it('with waitForIssuance=true, resolves with the final outcome after polling', async () => {
+      const gateway = new ECPayTicketGateway({
+        issuePoll: { intervalMs: 10, timeoutMs: 5_000 },
+      });
+
+      const issueDecrypted: ECPayTicketIssueResponseDecrypted = {
+        RtnCode: 1,
+        RtnMsg: 'OK',
+        MerchantTradeNo: 'M002',
+        TicketTradeNo: 'TT2',
+        TicketData: [{ ItemName: 'X', TicketPrice: 100, TicketAmount: 1 }],
+      };
+
+      const responses: ECPayTicketQueryIssueResultResponseDecrypted[] = [
+        { RtnCode: 1, RtnMsg: 'OK', MerchantTradeNo: 'M002', Status: 3, Remark: '' },
+        { RtnCode: 1, RtnMsg: 'OK', MerchantTradeNo: 'M002', Status: 1, Remark: '' },
+      ];
+
+      let call = 0;
+
+      post.mockImplementation(async (url: string) => {
+        if (url.endsWith('/api/Ticket/Issue')) {
+          return { data: buildTicketResponseEnvelope(issueDecrypted) };
+        }
+
+        const next = responses[Math.min(call, responses.length - 1)];
+
+        call += 1;
+
+        return { data: buildTicketResponseEnvelope(next) };
+      });
+
+      const outcome = (await gateway.issue({
+        merchantTradeNo: 'M002',
+        issueType: ECPayIssueType.SERIAL_ONLY,
+        operator: 'Tester',
+        tickets: [{ itemName: 'X', ticketPrice: 100, ticketAmount: 1 }],
+        waitForIssuance: true,
+      })) as ECPayTicketIssueOutcome;
+
+      expect(outcome.status).toBe('success');
+      expect(outcome.merchantTradeNo).toBe('M002');
+    });
+  });
+
+  describe('queryIssueResult()', () => {
+    let post: jest.SpyInstance;
+
+    beforeEach(() => {
+      post = jest.spyOn(axios, 'post');
+    });
+
+    afterEach(() => {
+      post.mockRestore();
+    });
+
+    it.each([
+      [1, 'success'],
+      [2, 'failed'],
+      [3, 'processing'],
+    ])('maps Status=%d → %s', async (statusCode, expectedStatus) => {
+      const gateway = new ECPayTicketGateway();
+
+      const decrypted: ECPayTicketQueryIssueResultResponseDecrypted = {
+        RtnCode: 1,
+        RtnMsg: 'OK',
+        MerchantTradeNo: 'M003',
+        Status: statusCode,
+        Remark: statusCode === 2 ? 'reason' : '',
+      };
+
+      post.mockImplementation(async (url: string) => {
+        expect(url).toBe('https://ecticket-stage.ecpay.com.tw/api/Ticket/QueryIssueResult');
+
+        return { data: buildTicketResponseEnvelope(decrypted) };
+      });
+
+      const outcome = await gateway.queryIssueResult({ merchantTradeNo: 'M003' });
+
+      expect(outcome.status).toBe(expectedStatus);
+      expect(outcome.merchantTradeNo).toBe('M003');
+
+      if (outcome.status === 'failed') {
+        expect(outcome.remark).toBe('reason');
+      }
+    });
+
+    it('rejects when neither merchantTradeNo nor freeTradeNo provided', async () => {
+      const gateway = new ECPayTicketGateway();
+
+      await expect(gateway.queryIssueResult({})).rejects.toThrow(/merchantTradeNo or freeTradeNo/);
+    });
+  });
+
+  describe('queryOrderInfo()', () => {
+    let post: jest.SpyInstance;
+
+    beforeEach(() => {
+      post = jest.spyOn(axios, 'post');
+    });
+
+    afterEach(() => {
+      post.mockRestore();
+    });
+
+    it('maps the full order + ticket list, including UseStatus enum mapping', async () => {
+      const gateway = new ECPayTicketGateway();
+
+      const decrypted: ECPayTicketQueryOrderInfoResponseDecrypted = {
+        RtnCode: 1,
+        RtnMsg: 'OK',
+        MerchantID: '2000132',
+        MerchantTradeNo: 'M004',
+        TicketTradeNo: 'TT4',
+        PaymentProvider: '1',
+        PaymentType: '1',
+        Status: 1,
+        Remark: '',
+        IssueDate: '2026/05/18 14:30:00',
+        IssueType: ECPayIssueType.SERIAL_ONLY,
+        EscrowExpiredDate: '20260918',
+        TotalCount: 4,
+        TradeAmount: 400,
+        RedeemCount: 1,
+        RedeemAmount: 100,
+        RefundCount: 1,
+        RefundAmount: 100,
+        TotalRefundFee: 0,
+        UnUsedCount: 1,
+        UnUsedAmount: 100,
+        ExpiredCount: 1,
+        TicketList: [
+          { TicketNo: 'TKT-001', UseStatus: 1, TicketType: '1', TicketAmount: 100 },
+          { TicketNo: 'TKT-002', UseStatus: 2, TicketType: '1', TicketAmount: 100, WriteOffDate: '20260601' },
+          { TicketNo: 'TKT-003', UseStatus: 3, TicketType: '2', TicketAmount: 100, RefundDate: '20260602' },
+          { TicketNo: 'TKT-004', UseStatus: 4, TicketType: '2', TicketAmount: 100, ExpiredDate: '20260603' },
+        ],
+      };
+
+      post.mockImplementation(async () => ({ data: buildTicketResponseEnvelope(decrypted) }));
+
+      const info = await gateway.queryOrderInfo({ merchantTradeNo: 'M004' });
+
+      expect(info.merchantTradeNo).toBe('M004');
+      expect(info.totalCount).toBe(4);
+      expect(info.tradeAmount).toBe(400);
+      expect(info.issueDate).toBeInstanceOf(Date);
+      expect(info.tickets).toHaveLength(4);
+      expect(info.tickets[0].useStatus).toBe(ECPayTicketUseStatus.UNUSED);
+      expect(info.tickets[1].useStatus).toBe(ECPayTicketUseStatus.REDEEMED);
+      expect(info.tickets[2].useStatus).toBe(ECPayTicketUseStatus.REFUNDED);
+      expect(info.tickets[3].useStatus).toBe(ECPayTicketUseStatus.EXPIRED);
+      expect(info.tickets[1].writeOffDate).toBeInstanceOf(Date);
+    });
+  });
+
+  describe('built-in callback server', () => {
+    function postToServer(
+      port: number,
+      path: string,
+      body: object,
+    ): Promise<{ statusCode: number | undefined; body: string }> {
+      return new Promise((resolve, reject) => {
+        const req = http.request(
+          {
+            hostname: '127.0.0.1',
+            port,
+            path,
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+          },
+          res => {
+            const chunks: Buffer[] = [];
+
+            res.on('data', chunk => chunks.push(chunk as Buffer));
+            res.on('end', () => resolve({ statusCode: res.statusCode, body: Buffer.concat(chunks).toString('utf8') }));
+          },
+        );
+
+        req.on('error', reject);
+        req.write(JSON.stringify(body));
+        req.end();
+      });
+    }
+
+    function getPort(gateway: ECPayTicketGateway): number {
+      const addr = gateway._server!.address() as AddressInfo;
+
+      return addr.port;
+    }
+
+    it('emits SERVER_LISTENED on startup', done => {
+      const gateway = new ECPayTicketGateway({
+        withServer: true,
+        onServerListen: (): void => {
+          gateway._server?.close(done);
+        },
+      });
+    });
+
+    it('emits TICKET_REFUND_NOTIFIED on valid refund callback and replies 1|OK', done => {
+      const gateway = new ECPayTicketGateway({
+        withServer: true,
+        onServerListen: async (): Promise<void> => {
+          gateway.emitter.on(ECPayTicketEvents.TICKET_REFUND_NOTIFIED, (n: ECPayTicketRefundNotification) => {
+            expect(n.ticketTradeNo).toBe('TT-REF');
+            expect(n.refundAmount).toBe(200);
+            gateway._server?.close(done);
+          });
+
+          const port = getPort(gateway);
+          const envelope = buildTicketResponseEnvelope({
+            MerchantTradeNo: 'MR1',
+            TicketTradeNo: 'TT-REF',
+            RefundAmount: 200,
+            Remark: 'customer refund',
+          });
+
+          const { statusCode, body } = await postToServer(port, '/payments/ecpay/ticket/refund', envelope);
+
+          expect(statusCode).toBe(200);
+          expect(body).toBe('1|OK');
+        },
+      });
+    });
+
+    it('emits TICKET_USE_STATUS_CHANGED on valid use-status callback', done => {
+      const gateway = new ECPayTicketGateway({
+        withServer: true,
+        onServerListen: async (): Promise<void> => {
+          gateway.emitter.on(ECPayTicketEvents.TICKET_USE_STATUS_CHANGED, (n: ECPayTicketUseStatusNotification) => {
+            expect(n.ticketNo).toBe('TKT-USE-001');
+            expect(n.useStatus).toBe(ECPayTicketUseStatus.REDEEMED);
+            gateway._server?.close(done);
+          });
+
+          const port = getPort(gateway);
+          const envelope = buildTicketResponseEnvelope({
+            MerchantTradeNo: 'MR2',
+            TicketTradeNo: 'TT-USE',
+            TicketNo: 'TKT-USE-001',
+            UseStatus: 2,
+          });
+
+          await postToServer(port, '/payments/ecpay/ticket/use-status', envelope);
+        },
+      });
+    });
+
+    it('rejects callback with invalid CheckMacValue', done => {
+      const gateway = new ECPayTicketGateway({
+        withServer: true,
+        onServerListen: async (): Promise<void> => {
+          const port = getPort(gateway);
+          const envelope = buildTicketResponseEnvelope({ TicketTradeNo: 'X' });
+
+          envelope.CheckMacValue = 'TAMPERED';
+
+          let refundFired = false;
+
+          gateway.emitter.on(ECPayTicketEvents.TICKET_REFUND_NOTIFIED, () => {
+            refundFired = true;
+          });
+
+          const { statusCode, body } = await postToServer(port, '/payments/ecpay/ticket/refund', envelope);
+
+          expect(statusCode).toBe(400);
+          expect(body).toBe('0|InvalidCheckMacValue');
+          expect(refundFired).toBe(false);
+
+          gateway._server?.close(done);
+        },
+      });
+    });
+
+    it('returns 404 for unknown path', done => {
+      const gateway = new ECPayTicketGateway({
+        withServer: true,
+        onServerListen: async (): Promise<void> => {
+          const port = getPort(gateway);
+          const { statusCode } = await postToServer(port, '/random/path', {});
+
+          expect(statusCode).toBe(404);
+          gateway._server?.close(done);
+        },
+      });
+    });
+  });
+
+  it('issue() with withServer=false does not auto-fill NotifyURL', async () => {
+    const gateway = new ECPayTicketGateway({
+      issuePoll: { intervalMs: 60_000, timeoutMs: 60_000 },
+    });
+
+    const post = jest.spyOn(axios, 'post');
+
+    post.mockImplementation(async (_url: string, body: unknown) => {
+      const parsed = JSON.parse(body as string);
+      const data = parsed.Data;
+      // 用 gateway 自己解密以驗證 plaintext 中不含 NotifyURL
+      // @ts-expect-error private access for white-box validation
+      const decrypted = gateway.decrypt(data) as Record<string, unknown>;
+
+      expect(decrypted.RefundNotifyURL).toBeUndefined();
+      expect(decrypted.UseStatusNotifyURL).toBeUndefined();
+
+      return {
+        data: buildTicketResponseEnvelope<ECPayTicketIssueResponseDecrypted>({
+          RtnCode: 1,
+          RtnMsg: 'OK',
+          MerchantTradeNo: 'M005',
+          TicketTradeNo: 'TT5',
+          TicketData: [],
+        }),
+      };
+    });
+
+    await gateway.issue({
+      merchantTradeNo: 'M005',
+      issueType: ECPayIssueType.PAPER,
+      printType: ECPayPrintType.ECPAY,
+      operator: 'Tester',
+      tickets: [{ itemNo: 'I1', ticketAmount: 1 }],
+    });
+
+    post.mockRestore();
+  });
+});

--- a/packages/payments-adapter-ecpay/__tests__/ecpay-ticket-gateway.spec.ts
+++ b/packages/payments-adapter-ecpay/__tests__/ecpay-ticket-gateway.spec.ts
@@ -8,6 +8,7 @@ import http, { createServer } from 'http';
 import {
   ECPayIssueType,
   ECPayPrintType,
+  ECPayTicketCallbackError,
   ECPayTicketEvents,
   ECPayTicketGateway,
   ECPayTicketIssueOutcome,
@@ -498,6 +499,103 @@ describe('ECPayTicketGateway', () => {
           gateway._server?.close(done);
         },
       });
+    });
+  });
+
+  describe('framework-agnostic notification handlers (no built-in server)', () => {
+    it('handleRefundNotification returns parsed notification and emits event', () => {
+      const gateway = new ECPayTicketGateway();
+
+      const envelope = buildTicketResponseEnvelope({
+        MerchantTradeNo: 'M-REF-1',
+        TicketTradeNo: 'TT-REF-1',
+        RefundAmount: 350,
+        Remark: 'customer requested',
+      });
+
+      let emitted: ECPayTicketRefundNotification | undefined;
+
+      gateway.emitter.on(ECPayTicketEvents.TICKET_REFUND_NOTIFIED, n => {
+        emitted = n;
+      });
+
+      const result = gateway.handleRefundNotification(envelope);
+
+      expect(result.merchantTradeNo).toBe('M-REF-1');
+      expect(result.ticketTradeNo).toBe('TT-REF-1');
+      expect(result.refundAmount).toBe(350);
+      expect(result.remark).toBe('customer requested');
+      expect(emitted).toBe(result);
+    });
+
+    it('handleUseStatusNotification returns parsed notification and emits event', () => {
+      const gateway = new ECPayTicketGateway();
+
+      const envelope = buildTicketResponseEnvelope({
+        MerchantTradeNo: 'M-USE-1',
+        TicketTradeNo: 'TT-USE-1',
+        TicketNo: 'TKT-USE-X',
+        UseStatus: 2,
+      });
+
+      let emitted: ECPayTicketUseStatusNotification | undefined;
+
+      gateway.emitter.on(ECPayTicketEvents.TICKET_USE_STATUS_CHANGED, n => {
+        emitted = n;
+      });
+
+      const result = gateway.handleUseStatusNotification(envelope);
+
+      expect(result.ticketNo).toBe('TKT-USE-X');
+      expect(result.useStatus).toBe(ECPayTicketUseStatus.REDEEMED);
+      expect(emitted).toBe(result);
+    });
+
+    it('handleRefundNotification throws ECPayTicketCallbackError(INVALID_CHECKMAC) on tampered envelope', () => {
+      const gateway = new ECPayTicketGateway();
+
+      const envelope = buildTicketResponseEnvelope({ TicketTradeNo: 'X', RefundAmount: 1 });
+
+      envelope.CheckMacValue = 'TAMPERED';
+
+      let fired = false;
+
+      gateway.emitter.on(ECPayTicketEvents.TICKET_REFUND_NOTIFIED, () => {
+        fired = true;
+      });
+
+      try {
+        gateway.handleRefundNotification(envelope);
+        throw new Error('expected to throw');
+      } catch (err) {
+        expect(err).toBeInstanceOf(ECPayTicketCallbackError);
+        expect((err as ECPayTicketCallbackError).code).toBe('INVALID_CHECKMAC');
+      }
+
+      expect(fired).toBe(false);
+    });
+
+    it('handleUseStatusNotification throws ECPayTicketCallbackError(INVALID_DATA) when Data cannot be decrypted', () => {
+      const gateway = new ECPayTicketGateway();
+
+      const garbageData = 'NOT-A-VALID-AES-BASE64-PAYLOAD';
+      const envelope = {
+        PlatformID: '',
+        MerchantID: '2000132',
+        RpHeader: { Timestamp: Math.round(Date.now() / 1000) },
+        TransCode: 1,
+        TransMsg: '',
+        Data: garbageData,
+        CheckMacValue: computeTicketCheckMacValue(garbageData),
+      };
+
+      try {
+        gateway.handleUseStatusNotification(envelope);
+        throw new Error('expected to throw');
+      } catch (err) {
+        expect(err).toBeInstanceOf(ECPayTicketCallbackError);
+        expect((err as ECPayTicketCallbackError).code).toBe('INVALID_DATA');
+      }
     });
   });
 

--- a/packages/payments-adapter-ecpay/__tests__/payment-query.spec.ts
+++ b/packages/payments-adapter-ecpay/__tests__/payment-query.spec.ts
@@ -62,6 +62,10 @@ describe('ECPayPayment', () => {
     return mockServer;
   });
 
+  afterAll(() => {
+    mockedCreateServer.mockRestore();
+  });
+
   describe('Waiting withServer mode server listen', () => {
     it('should reject query on server not ready', done => {
       const payment = new ECPayPayment({

--- a/packages/payments-adapter-ecpay/__utils__/ticket-envelope.ts
+++ b/packages/payments-adapter-ecpay/__utils__/ticket-envelope.ts
@@ -1,0 +1,56 @@
+import { createCipheriv } from 'crypto';
+import { ecpaySha256, ecpayUrlEncode } from '../src/ecpay-utils';
+
+export interface TicketCreds {
+  hashKey: string;
+  hashIv: string;
+}
+
+export const DEFAULT_TICKET_CREDS: TicketCreds = {
+  hashKey: '5294y06JbISpM5x9',
+  hashIv: 'v77hoKGq4kWxNNIS',
+};
+
+export function encryptTicketData<T>(data: T, creds: TicketCreds = DEFAULT_TICKET_CREDS): string {
+  const encoded = encodeURIComponent(JSON.stringify(data));
+  const cipher = createCipheriv('aes-128-cbc', creds.hashKey, creds.hashIv);
+
+  cipher.setAutoPadding(true);
+
+  return [cipher.update(encoded, 'utf8', 'base64'), cipher.final('base64')].join('');
+}
+
+export function computeTicketCheckMacValue(encryptedData: string, creds: TicketCreds = DEFAULT_TICKET_CREDS): string {
+  return ecpaySha256(ecpayUrlEncode(`HashKey=${creds.hashKey}&Data=${encryptedData}&HashIV=${creds.hashIv}`));
+}
+
+export function buildTicketResponseEnvelope<T>(
+  decryptedData: T,
+  options?: {
+    merchantId?: string;
+    transCode?: number;
+    transMsg?: string;
+    creds?: TicketCreds;
+  },
+): {
+  PlatformID: string;
+  MerchantID: string;
+  RpHeader: { Timestamp: number };
+  TransCode: number;
+  TransMsg: string;
+  Data: string;
+  CheckMacValue: string;
+} {
+  const creds = options?.creds ?? DEFAULT_TICKET_CREDS;
+  const encrypted = encryptTicketData(decryptedData, creds);
+
+  return {
+    PlatformID: '',
+    MerchantID: options?.merchantId ?? '2000132',
+    RpHeader: { Timestamp: Math.round(Date.now() / 1000) },
+    TransCode: options?.transCode ?? 1,
+    TransMsg: options?.transMsg ?? '',
+    Data: encrypted,
+    CheckMacValue: computeTicketCheckMacValue(encrypted, creds),
+  };
+}

--- a/packages/payments-adapter-ecpay/src/ecpay-payment.ts
+++ b/packages/payments-adapter-ecpay/src/ecpay-payment.ts
@@ -615,7 +615,9 @@ export class ECPayPayment<CM extends ECPayCommitMessage = ECPayCommitMessage>
 
   async prepare<P extends CM>(orderInput: GetOrderInput<P>): Promise<ECPayOrder<P>> {
     if (!this.isGatewayReady) {
-      throw new Error('Please waiting gateway ready');
+      throw new Error(
+        '[ECPayPayment] Gateway is not ready yet. Wait for the SERVER_LISTENED event before calling API methods.',
+      );
     }
 
     if (
@@ -882,7 +884,9 @@ export class ECPayPayment<CM extends ECPayCommitMessage = ECPayCommitMessage>
 
   async query<T extends ECPayOrder<ECPayCommitMessage>>(id: string): Promise<T> {
     if (!this.isGatewayReady) {
-      throw new Error('Please waiting gateway ready');
+      throw new Error(
+        '[ECPayPayment] Gateway is not ready yet. Wait for the SERVER_LISTENED event before calling API methods.',
+      );
     }
 
     const date = new Date();
@@ -1038,7 +1042,9 @@ export class ECPayPayment<CM extends ECPayCommitMessage = ECPayCommitMessage>
 
   async getCreditCardTradeStatus(gwsr: string, amount: number): Promise<ECPayCreditCardOrderStatus> {
     if (!this.isGatewayReady) {
-      throw new Error('Please waiting gateway ready');
+      throw new Error(
+        '[ECPayPayment] Gateway is not ready yet. Wait for the SERVER_LISTENED event before calling API methods.',
+      );
     }
 
     const payload = this.addMac<ECPayCreditCardDetailQueryPayload>({
@@ -1076,7 +1082,9 @@ export class ECPayPayment<CM extends ECPayCommitMessage = ECPayCommitMessage>
 
   async doOrderAction(order: ECPayOrder<ECPayCommitMessage>, action: 'R' | 'N', amount: number): Promise<void> {
     if (!this.isGatewayReady) {
-      throw new Error('Please waiting gateway ready');
+      throw new Error(
+        '[ECPayPayment] Gateway is not ready yet. Wait for the SERVER_LISTENED event before calling API methods.',
+      );
     }
 
     const payload = this.addMac<ECPayOrderActionPayload>({
@@ -1147,7 +1155,9 @@ export class ECPayPayment<CM extends ECPayCommitMessage = ECPayCommitMessage>
 
   async prepareBindCard(memberId: string, finishRedirectURL?: string): Promise<ECPayBindCardRequest> {
     if (!this.isGatewayReady) {
-      throw new Error('Please waiting gateway ready');
+      throw new Error(
+        '[ECPayPayment] Gateway is not ready yet. Wait for the SERVER_LISTENED event before calling API methods.',
+      );
     }
 
     const payload = this.addMac<ECPayBindCardRequestPayload>({

--- a/packages/payments-adapter-ecpay/src/ecpay-payment.ts
+++ b/packages/payments-adapter-ecpay/src/ecpay-payment.ts
@@ -1,4 +1,4 @@
-import { createHash, randomBytes } from 'crypto';
+import { randomBytes } from 'crypto';
 import {
   PaymentGateway,
   PaymentEvents,
@@ -64,6 +64,7 @@ import {
 import { ECPayChannel, ECPayCVS, ECPayPaymentPeriodType, NUMERIC_CALLBACK_KEYS } from './constants';
 import { ECPayOrder } from './ecpay-order';
 import { ECPayBindCardRequest } from './ecpay-bind-card-request';
+import { ecpaySha256, ecpayUrlEncode } from './ecpay-utils';
 
 const debugPayment = debug('Rytass:Payment:ECPay');
 
@@ -176,28 +177,17 @@ export class ECPayPayment<CM extends ECPayCommitMessage = ECPayCommitMessage>
   }
 
   private addMac<T extends Record<string, string>>(payload: Omit<T, 'CheckMacValue'>): T {
-    const mac = createHash('sha256')
-      .update(
-        encodeURIComponent(
-          [
-            ['HashKey', this.hashKey],
-            ...Object.entries(payload).sort(([aKey], [bKey]) => (aKey.toLowerCase() < bKey.toLowerCase() ? -1 : 1)),
-            ['HashIV', this.hashIv],
-          ]
-            .map(([key, value]) => `${key}=${value}`)
-            .join('&'),
-        )
-          .toLowerCase()
-          .replace(/'/g, '%27')
-          .replace(/~/g, '%7e')
-          .replace(/%20/g, '+'),
-      )
-      .digest('hex')
-      .toUpperCase();
+    const raw = [
+      ['HashKey', this.hashKey],
+      ...Object.entries(payload).sort(([aKey], [bKey]) => (aKey.toLowerCase() < bKey.toLowerCase() ? -1 : 1)),
+      ['HashIV', this.hashIv],
+    ]
+      .map(([key, value]) => `${key}=${value}`)
+      .join('&');
 
     return {
       ...payload,
-      CheckMacValue: mac,
+      CheckMacValue: ecpaySha256(ecpayUrlEncode(raw)),
     } as unknown as T;
   }
 

--- a/packages/payments-adapter-ecpay/src/ecpay-ticket-gateway.ts
+++ b/packages/payments-adapter-ecpay/src/ecpay-ticket-gateway.ts
@@ -1,0 +1,584 @@
+import axios from 'axios';
+import debug from 'debug';
+import { createCipheriv, createDecipheriv } from 'crypto';
+import { EventEmitter } from 'events';
+import { createServer, IncomingMessage, Server, ServerResponse } from 'http';
+import { LRUCache } from 'lru-cache';
+import { DateTime } from 'luxon';
+import { ecpaySha256, ecpayUrlEncode } from './ecpay-utils';
+import {
+  ECPAY_TICKET_RTN_CODE_SUCCESS,
+  ECPAY_TICKET_TRANS_CODE_SUCCESS,
+  ECPayTicketBaseUrls,
+  ECPayTicketEvents,
+  ECPayTicketGatewayOptions,
+  ECPayTicketInfo,
+  ECPayTicketIssueInput,
+  ECPayTicketIssueOutcome,
+  ECPayTicketIssueReceipt,
+  ECPayTicketIssueRequestBody,
+  ECPayTicketIssueResponseDecrypted,
+  ECPayTicketIssueStatusCode,
+  ECPayTicketListResponseItem,
+  ECPayTicketOrderInfo,
+  ECPayTicketQueryIssueResultRequestBody,
+  ECPayTicketQueryIssueResultResponseDecrypted,
+  ECPayTicketQueryOrderInfoRequestBody,
+  ECPayTicketQueryOrderInfoResponseDecrypted,
+  ECPayTicketRefundNotification,
+  ECPayTicketRequestEnvelope,
+  ECPayTicketResponseEnvelope,
+  ECPayTicketType,
+  ECPayTicketUseStatusNotification,
+  IssuedTicketRecord,
+  IssuedTicketsCache,
+  parseTicketUseStatus,
+} from './ecpay-ticket-typings';
+
+const debugTicket = debug('Rytass:Payment:ECPay:Ticket');
+
+const DEFAULT_POLL_INTERVAL_MS = 30_000;
+const DEFAULT_POLL_TIMEOUT_MS = 6 * 60_000;
+const DEFAULT_CACHE_TTL_MS = 24 * 60 * 60 * 1000;
+const TICKET_TYPE_MAP: Record<string, ECPayTicketType> = {
+  '1': ECPayTicketType.REDEMPTION,
+  '2': ECPayTicketType.GIFT,
+};
+
+export class ECPayTicketGateway {
+  private readonly merchantId: string = '2000132';
+  private readonly hashKey: string = '5294y06JbISpM5x9';
+  private readonly hashIv: string = 'v77hoKGq4kWxNNIS';
+  private readonly baseUrl: string = ECPayTicketBaseUrls.DEVELOPMENT;
+  private readonly platformId?: string;
+
+  private readonly pollIntervalMs: number;
+  private readonly pollTimeoutMs: number;
+
+  private readonly issuedTicketsCache: IssuedTicketsCache;
+
+  private readonly withServer: boolean | 'ngrok' = false;
+  private serverHost: string = 'http://localhost:3000';
+  private readonly refundNotifyPath: string = '/payments/ecpay/ticket/refund';
+  private readonly useStatusNotifyPath: string = '/payments/ecpay/ticket/use-status';
+  private readonly serverListener: (req: IncomingMessage, res: ServerResponse) => void = (req, res) =>
+    this.defaultServerListener(req, res);
+
+  private isGatewayReady = false;
+
+  readonly emitter = new EventEmitter();
+  _server?: Server;
+
+  constructor(options?: ECPayTicketGatewayOptions) {
+    this.merchantId = options?.merchantId ?? this.merchantId;
+    this.hashKey = options?.hashKey ?? this.hashKey;
+    this.hashIv = options?.hashIv ?? this.hashIv;
+    this.baseUrl = options?.baseUrl ?? this.baseUrl;
+    this.platformId = options?.platformId;
+
+    this.pollIntervalMs = options?.issuePoll?.intervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+    this.pollTimeoutMs = options?.issuePoll?.timeoutMs ?? DEFAULT_POLL_TIMEOUT_MS;
+
+    this.serverHost = options?.serverHost ?? this.serverHost;
+    this.refundNotifyPath = options?.refundNotifyPath ?? this.refundNotifyPath;
+    this.useStatusNotifyPath = options?.useStatusNotifyPath ?? this.useStatusNotifyPath;
+
+    if (options?.serverListener) {
+      this.serverListener = options.serverListener;
+    }
+
+    const lruCache = options?.issuedTicketsCache
+      ? undefined
+      : new LRUCache<string, IssuedTicketRecord>({
+          ttlAutopurge: true,
+          ttl: options?.issuedTicketsCacheTTL ?? DEFAULT_CACHE_TTL_MS,
+        });
+
+    this.issuedTicketsCache = options?.issuedTicketsCache ?? {
+      get: async (key: string): Promise<IssuedTicketRecord | undefined> => lruCache!.get(key),
+      set: async (key: string, value: IssuedTicketRecord): Promise<void> => {
+        lruCache!.set(key, value);
+      },
+    };
+
+    if (options?.onServerListen) {
+      this.emitter.on(ECPayTicketEvents.SERVER_LISTENED, options.onServerListen);
+    }
+
+    this.emitter.on(ECPayTicketEvents.SERVER_LISTENED, () => {
+      this.isGatewayReady = true;
+    });
+
+    if (options?.withServer) {
+      this.withServer = options.withServer;
+
+      this.createCallbackServer(options.withServer === 'ngrok');
+    } else {
+      this.isGatewayReady = true;
+    }
+  }
+
+  private encrypt<T>(data: T): string {
+    const encodedData = encodeURIComponent(JSON.stringify(data));
+    const cipher = createCipheriv('aes-128-cbc', this.hashKey, this.hashIv);
+
+    cipher.setAutoPadding(true);
+
+    return [cipher.update(encodedData, 'utf8', 'base64'), cipher.final('base64')].join('');
+  }
+
+  private decrypt<T>(encryptedData: string): T {
+    const decipher = createDecipheriv('aes-128-cbc', this.hashKey, this.hashIv);
+
+    return JSON.parse(
+      decodeURIComponent([decipher.update(encryptedData, 'base64', 'utf8'), decipher.final('utf8')].join('')),
+    );
+  }
+
+  private generateCheckMacValue(encryptedData: string): string {
+    return ecpaySha256(ecpayUrlEncode(`HashKey=${this.hashKey}&Data=${encryptedData}&HashIV=${this.hashIv}`));
+  }
+
+  private verifyResponseEnvelope(envelope: ECPayTicketResponseEnvelope): boolean {
+    return this.generateCheckMacValue(envelope.Data) === envelope.CheckMacValue;
+  }
+
+  private buildEnvelope(encryptedData: string): ECPayTicketRequestEnvelope {
+    return {
+      ...(this.platformId ? { PlatformID: this.platformId } : {}),
+      MerchantID: this.merchantId,
+      RqHeader: {
+        Timestamp: Math.round(Date.now() / 1000),
+      },
+      Data: encryptedData,
+      CheckMacValue: this.generateCheckMacValue(encryptedData),
+    };
+  }
+
+  private async postEnvelope<TBody, TDecrypted>(path: string, body: TBody): Promise<TDecrypted> {
+    if (!this.isGatewayReady) {
+      throw new Error('Please waiting gateway ready');
+    }
+
+    const encryptedData = this.encrypt<TBody>(body);
+    const envelope = this.buildEnvelope(encryptedData);
+
+    const { data } = await axios.post<ECPayTicketResponseEnvelope>(`${this.baseUrl}${path}`, JSON.stringify(envelope), {
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    if (data.TransCode !== ECPAY_TICKET_TRANS_CODE_SUCCESS) {
+      throw new Error(`ECPay ticket transport error: (${data.TransCode}) ${data.TransMsg}`);
+    }
+
+    if (!this.verifyResponseEnvelope(data)) {
+      throw new Error('Invalid CheckMacValue');
+    }
+
+    return this.decrypt<TDecrypted>(data.Data);
+  }
+
+  private formatDate(date?: Date): string | undefined {
+    if (!date) return undefined;
+
+    return DateTime.fromJSDate(date).toFormat('yyyyMMdd');
+  }
+
+  private parseDateYMD(s?: string): Date | undefined {
+    if (!s) return undefined;
+
+    return DateTime.fromFormat(s, 'yyyyMMdd').toJSDate();
+  }
+
+  private parseTimestamp(s?: string): Date | undefined {
+    if (!s) return undefined;
+
+    const dt = DateTime.fromFormat(s, 'yyyy/MM/dd HH:mm:ss');
+
+    return dt.isValid ? dt.toJSDate() : undefined;
+  }
+
+  private validateIssueInput(input: ECPayTicketIssueInput): void {
+    if (!input.merchantTradeNo && !input.freeTradeNo) {
+      throw new Error('Either merchantTradeNo or freeTradeNo must be provided');
+    }
+
+    if (input.tickets.length === 0) {
+      throw new Error('At least one ticket entry is required');
+    }
+
+    // TODO(user): IssueType-specific required-field validation.
+    // 不同的 IssueType 在綠界文件上有不同的條件必填欄位：
+    //   - CVS (1)         → CustomerEmail（取貨通知信）必填
+    //   - PAPER (2)       → printType 必填；若 PrintType=MERCHANT，CustomerName/CustomerAddress 必填
+    //   - ELECTRONIC (3)  → isImmediate 必填；CustomerName/CustomerPhone/CustomerEmail 必填
+    //   - SERIAL_ONLY (4) → 每筆 ticket 的 itemName 與 ticketPrice 必填
+    //
+    // 請在這裡補上前置驗證並拋出清楚的 Error。
+    // 設計權衡：太嚴格會擋住未來綠界放寬規則的情境；太寬鬆則錯誤要等綠界 RtnCode 才浮現。
+  }
+
+  private buildIssueRequestBody(input: ECPayTicketIssueInput): ECPayTicketIssueRequestBody {
+    const refundNotifyUrl =
+      input.refundNotifyUrl ?? (this.withServer ? `${this.serverHost}${this.refundNotifyPath}` : undefined);
+
+    const useStatusNotifyUrl =
+      input.useStatusNotifyUrl ?? (this.withServer ? `${this.serverHost}${this.useStatusNotifyPath}` : undefined);
+
+    return {
+      MerchantID: this.merchantId,
+      ...(input.merchantTradeNo ? { MerchantTradeNo: input.merchantTradeNo } : {}),
+      ...(input.freeTradeNo ? { FreeTradeNo: input.freeTradeNo } : {}),
+      IssueType: input.issueType,
+      ...(input.printType ? { PrintType: input.printType } : {}),
+      ...(input.isImmediate ? { IsImmediate: input.isImmediate } : {}),
+      ...(refundNotifyUrl ? { RefundNotifyURL: refundNotifyUrl } : {}),
+      ...(useStatusNotifyUrl ? { UseStatusNotifyURL: useStatusNotifyUrl } : {}),
+      ...(input.storeId ? { StoreID: input.storeId } : {}),
+      Operator: input.operator,
+      ...(input.customer?.name ? { CustomerName: input.customer.name } : {}),
+      ...(input.customer?.phone ? { CustomerPhone: input.customer.phone } : {}),
+      ...(input.customer?.email ? { CustomerEmail: input.customer.email } : {}),
+      ...(input.customer?.address ? { CustomerAddress: input.customer.address } : {}),
+      TicketInfo: input.tickets.map(t => ({
+        ...(t.itemNo ? { ItemNo: t.itemNo } : {}),
+        ...(t.itemName ? { ItemName: t.itemName } : {}),
+        ...(t.ticketPrice !== undefined ? { TicketPrice: t.ticketPrice } : {}),
+        TicketAmount: t.ticketAmount,
+        ...(this.formatDate(t.startDate) ? { StartDate: this.formatDate(t.startDate) } : {}),
+        ...(this.formatDate(t.expireDate) ? { ExpireDate: this.formatDate(t.expireDate) } : {}),
+      })),
+    };
+  }
+
+  private toOutcome(decrypted: ECPayTicketQueryIssueResultResponseDecrypted): ECPayTicketIssueOutcome {
+    const ids = {
+      ...(decrypted.MerchantTradeNo ? { merchantTradeNo: decrypted.MerchantTradeNo } : {}),
+      ...(decrypted.FreeTradeNo ? { freeTradeNo: decrypted.FreeTradeNo } : {}),
+    };
+
+    switch (decrypted.Status) {
+      case ECPayTicketIssueStatusCode.SUCCESS:
+        return { status: 'success', ...ids };
+      case ECPayTicketIssueStatusCode.FAILED:
+        return { status: 'failed', remark: decrypted.Remark, ...ids };
+      case ECPayTicketIssueStatusCode.PROCESSING:
+        return { status: 'processing', ...ids };
+      default:
+        throw new Error(`Unknown Status from ECPay: ${decrypted.Status}`);
+    }
+  }
+
+  private startBackgroundPolling(merchantTradeNo?: string, freeTradeNo?: string): Promise<ECPayTicketIssueOutcome> {
+    const deadline = Date.now() + this.pollTimeoutMs;
+
+    return new Promise(resolve => {
+      const poll = async (): Promise<void> => {
+        try {
+          const outcome = await this.queryIssueResult({ merchantTradeNo, freeTradeNo });
+
+          if (outcome.status === 'success') {
+            this.emitter.emit(ECPayTicketEvents.TICKET_ISSUED, outcome);
+            resolve(outcome);
+
+            return;
+          }
+
+          if (outcome.status === 'failed') {
+            this.emitter.emit(ECPayTicketEvents.TICKET_ISSUE_FAILED, outcome);
+            resolve(outcome);
+
+            return;
+          }
+
+          if (Date.now() >= deadline) {
+            const timeoutOutcome: ECPayTicketIssueOutcome = {
+              status: 'failed',
+              remark: 'Ticket issuance polling timed out',
+              ...(merchantTradeNo ? { merchantTradeNo } : {}),
+              ...(freeTradeNo ? { freeTradeNo } : {}),
+            };
+
+            this.emitter.emit(ECPayTicketEvents.TICKET_ISSUE_FAILED, timeoutOutcome);
+            resolve(timeoutOutcome);
+
+            return;
+          }
+
+          setTimeout(poll, this.pollIntervalMs);
+        } catch (error) {
+          const errorOutcome: ECPayTicketIssueOutcome = {
+            status: 'failed',
+            remark: error instanceof Error ? error.message : 'Polling error',
+            ...(merchantTradeNo ? { merchantTradeNo } : {}),
+            ...(freeTradeNo ? { freeTradeNo } : {}),
+          };
+
+          this.emitter.emit(ECPayTicketEvents.TICKET_ISSUE_FAILED, errorOutcome);
+          resolve(errorOutcome);
+        }
+      };
+
+      setTimeout(poll, this.pollIntervalMs);
+    });
+  }
+
+  async issue(input: ECPayTicketIssueInput): Promise<ECPayTicketIssueReceipt | ECPayTicketIssueOutcome> {
+    this.validateIssueInput(input);
+
+    const body = this.buildIssueRequestBody(input);
+    const decrypted = await this.postEnvelope<ECPayTicketIssueRequestBody, ECPayTicketIssueResponseDecrypted>(
+      '/api/Ticket/Issue',
+      body,
+    );
+
+    if (decrypted.RtnCode !== ECPAY_TICKET_RTN_CODE_SUCCESS) {
+      throw new Error(`ECPay ticket issue failed: (${decrypted.RtnCode}) ${decrypted.RtnMsg}`);
+    }
+
+    const receipt: ECPayTicketIssueReceipt = {
+      ...(decrypted.MerchantTradeNo ? { merchantTradeNo: decrypted.MerchantTradeNo } : {}),
+      ...(decrypted.FreeTradeNo ? { freeTradeNo: decrypted.FreeTradeNo } : {}),
+      ticketTradeNo: decrypted.TicketTradeNo,
+      tickets: decrypted.TicketData.map(t => ({
+        ...(t.ItemNo ? { itemNo: t.ItemNo } : {}),
+        ...(t.ItemName ? { itemName: t.ItemName } : {}),
+        ...(t.TicketPrice !== undefined ? { ticketPrice: t.TicketPrice } : {}),
+        ticketAmount: t.TicketAmount,
+      })),
+    };
+
+    const cacheKey = receipt.merchantTradeNo ?? receipt.freeTradeNo;
+
+    if (cacheKey) {
+      await this.issuedTicketsCache.set(cacheKey, {
+        ...(receipt.merchantTradeNo ? { merchantTradeNo: receipt.merchantTradeNo } : {}),
+        ...(receipt.freeTradeNo ? { freeTradeNo: receipt.freeTradeNo } : {}),
+        issueType: input.issueType,
+        ticketTradeNo: receipt.ticketTradeNo,
+        issuedAt: new Date(),
+      });
+    }
+
+    const pollingPromise = this.startBackgroundPolling(receipt.merchantTradeNo, receipt.freeTradeNo);
+
+    if (input.waitForIssuance) {
+      return pollingPromise;
+    }
+
+    return receipt;
+  }
+
+  async queryIssueResult(args: { merchantTradeNo?: string; freeTradeNo?: string }): Promise<ECPayTicketIssueOutcome> {
+    if (!args.merchantTradeNo && !args.freeTradeNo) {
+      throw new Error('Either merchantTradeNo or freeTradeNo must be provided');
+    }
+
+    const body: ECPayTicketQueryIssueResultRequestBody = {
+      MerchantID: this.merchantId,
+      ...(args.merchantTradeNo ? { MerchantTradeNo: args.merchantTradeNo } : {}),
+      ...(args.freeTradeNo ? { FreeTradeNo: args.freeTradeNo } : {}),
+    };
+
+    const decrypted = await this.postEnvelope<
+      ECPayTicketQueryIssueResultRequestBody,
+      ECPayTicketQueryIssueResultResponseDecrypted
+    >('/api/Ticket/QueryIssueResult', body);
+
+    if (decrypted.RtnCode !== ECPAY_TICKET_RTN_CODE_SUCCESS) {
+      throw new Error(`ECPay ticket query failed: (${decrypted.RtnCode}) ${decrypted.RtnMsg}`);
+    }
+
+    return this.toOutcome(decrypted);
+  }
+
+  async queryOrderInfo(args: {
+    merchantTradeNo?: string;
+    freeTradeNo?: string;
+    pageNum?: number;
+  }): Promise<ECPayTicketOrderInfo> {
+    if (!args.merchantTradeNo && !args.freeTradeNo) {
+      throw new Error('Either merchantTradeNo or freeTradeNo must be provided');
+    }
+
+    const body: ECPayTicketQueryOrderInfoRequestBody = {
+      MerchantID: this.merchantId,
+      ...(args.merchantTradeNo ? { MerchantTradeNo: args.merchantTradeNo } : {}),
+      ...(args.freeTradeNo ? { FreeTradeNo: args.freeTradeNo } : {}),
+      ...(args.pageNum !== undefined ? { PageNum: args.pageNum } : {}),
+    };
+
+    const decrypted = await this.postEnvelope<
+      ECPayTicketQueryOrderInfoRequestBody,
+      ECPayTicketQueryOrderInfoResponseDecrypted
+    >('/api/Ticket/QueryOrderInfo', body);
+
+    if (decrypted.RtnCode !== ECPAY_TICKET_RTN_CODE_SUCCESS) {
+      throw new Error(`ECPay ticket order info query failed: (${decrypted.RtnCode}) ${decrypted.RtnMsg}`);
+    }
+
+    return this.mapOrderInfo(decrypted);
+  }
+
+  private mapTicket(raw: ECPayTicketListResponseItem): ECPayTicketInfo {
+    const ticketType = TICKET_TYPE_MAP[raw.TicketType];
+
+    if (!ticketType) {
+      throw new Error(`Unknown ECPay ticket TicketType: ${raw.TicketType}`);
+    }
+
+    return {
+      ticketNo: raw.TicketNo,
+      useStatus: parseTicketUseStatus(raw.UseStatus),
+      ...(raw.ItemNo ? { itemNo: raw.ItemNo } : {}),
+      ...(raw.ItemName ? { itemName: raw.ItemName } : {}),
+      ticketType,
+      ticketAmount: raw.TicketAmount,
+      ...(this.parseDateYMD(raw.StartDate) ? { startDate: this.parseDateYMD(raw.StartDate) } : {}),
+      ...(this.parseDateYMD(raw.WriteOffDate) ? { writeOffDate: this.parseDateYMD(raw.WriteOffDate) } : {}),
+      ...(this.parseDateYMD(raw.RefundDate) ? { refundDate: this.parseDateYMD(raw.RefundDate) } : {}),
+      ...(this.parseDateYMD(raw.ExpiredDate) ? { expiredDate: this.parseDateYMD(raw.ExpiredDate) } : {}),
+      ...(raw.WriteOffNo ? { writeOffNo: raw.WriteOffNo } : {}),
+    };
+  }
+
+  private mapOrderInfo(decrypted: ECPayTicketQueryOrderInfoResponseDecrypted): ECPayTicketOrderInfo {
+    return {
+      ...(decrypted.MerchantTradeNo ? { merchantTradeNo: decrypted.MerchantTradeNo } : {}),
+      ...(decrypted.FreeTradeNo ? { freeTradeNo: decrypted.FreeTradeNo } : {}),
+      ticketTradeNo: decrypted.TicketTradeNo,
+      paymentProvider: decrypted.PaymentProvider,
+      paymentType: decrypted.PaymentType,
+      ...(decrypted.CreditTradeID !== undefined ? { creditTradeId: decrypted.CreditTradeID } : {}),
+      status: decrypted.Status,
+      remark: decrypted.Remark,
+      ...(this.parseTimestamp(decrypted.IssueDate) ? { issueDate: this.parseTimestamp(decrypted.IssueDate) } : {}),
+      issueType: decrypted.IssueType,
+      ...(decrypted.PrintType ? { printType: decrypted.PrintType } : {}),
+      customer: {
+        ...(decrypted.CustomerName ? { name: decrypted.CustomerName } : {}),
+        ...(decrypted.CustomerPhone ? { phone: decrypted.CustomerPhone } : {}),
+        ...(decrypted.CustomerEmail ? { email: decrypted.CustomerEmail } : {}),
+      },
+      ...(this.parseDateYMD(decrypted.EscrowExpiredDate)
+        ? { escrowExpiredDate: this.parseDateYMD(decrypted.EscrowExpiredDate) }
+        : {}),
+      totalCount: decrypted.TotalCount,
+      tradeAmount: decrypted.TradeAmount,
+      redeemCount: decrypted.RedeemCount,
+      redeemAmount: decrypted.RedeemAmount,
+      refundCount: decrypted.RefundCount,
+      refundAmount: decrypted.RefundAmount,
+      totalRefundFee: decrypted.TotalRefundFee,
+      unUsedCount: decrypted.UnUsedCount,
+      unUsedAmount: decrypted.UnUsedAmount,
+      expiredCount: decrypted.ExpiredCount,
+      tickets: decrypted.TicketList.map(t => this.mapTicket(t)),
+    };
+  }
+
+  private createCallbackServer(useNgrok: boolean): void {
+    const url = new URL(this.serverHost);
+
+    this._server = createServer((req, res) => this.serverListener(req, res));
+
+    const port = Number(url.port || 3000);
+
+    this._server.listen(port, '0.0.0.0', async () => {
+      if (useNgrok) {
+        if (!process.env.NGROK_AUTHTOKEN) {
+          throw new Error('[ECPayTicketGateway] NGROK_AUTHTOKEN is not set.');
+        }
+
+        const ngrokModule = await import('@ngrok/ngrok');
+        const ngrok = ngrokModule.default;
+
+        await ngrok.authtoken(process.env.NGROK_AUTHTOKEN);
+
+        const forwarder = await ngrok.forward(port);
+
+        this.serverHost = forwarder.url() as string;
+
+        debugTicket(`ECPayTicket Callback Server Listen on port ${port} with ngrok url: ${this.serverHost}`);
+      } else {
+        debugTicket(`ECPayTicket Callback Server Listen on port ${port}`);
+      }
+
+      this.emitter.emit(ECPayTicketEvents.SERVER_LISTENED, { url: this.serverHost });
+    });
+  }
+
+  public async defaultServerListener(req: IncomingMessage, res: ServerResponse): Promise<void> {
+    if (!req.url || req.method !== 'POST' || !~[this.refundNotifyPath, this.useStatusNotifyPath].indexOf(req.url)) {
+      res.writeHead(404);
+      res.end();
+
+      return;
+    }
+
+    const bufferArray: Buffer[] = [];
+
+    req.on('data', (chunk: Buffer) => {
+      bufferArray.push(chunk);
+    });
+
+    req.on('end', () => {
+      let envelope: ECPayTicketResponseEnvelope;
+
+      try {
+        envelope = JSON.parse(Buffer.concat(bufferArray).toString('utf8')) as ECPayTicketResponseEnvelope;
+      } catch {
+        res.writeHead(400);
+        res.end('0|InvalidPayload');
+
+        return;
+      }
+
+      if (!this.verifyResponseEnvelope(envelope)) {
+        debugTicket('Invalid CheckMacValue on callback');
+        res.writeHead(400);
+        res.end('0|InvalidCheckMacValue');
+
+        return;
+      }
+
+      let decrypted: Record<string, unknown>;
+
+      try {
+        decrypted = this.decrypt<Record<string, unknown>>(envelope.Data);
+      } catch {
+        res.writeHead(400);
+        res.end('0|InvalidData');
+
+        return;
+      }
+
+      if (req.url === this.refundNotifyPath) {
+        const notification: ECPayTicketRefundNotification = {
+          ...(typeof decrypted.MerchantTradeNo === 'string' ? { merchantTradeNo: decrypted.MerchantTradeNo } : {}),
+          ...(typeof decrypted.FreeTradeNo === 'string' ? { freeTradeNo: decrypted.FreeTradeNo } : {}),
+          ticketTradeNo: String(decrypted.TicketTradeNo ?? ''),
+          refundAmount: Number(decrypted.RefundAmount ?? 0),
+          ...(typeof decrypted.Remark === 'string' ? { remark: decrypted.Remark } : {}),
+          raw: decrypted,
+        };
+
+        this.emitter.emit(ECPayTicketEvents.TICKET_REFUND_NOTIFIED, notification);
+      } else {
+        const notification: ECPayTicketUseStatusNotification = {
+          ...(typeof decrypted.MerchantTradeNo === 'string' ? { merchantTradeNo: decrypted.MerchantTradeNo } : {}),
+          ...(typeof decrypted.FreeTradeNo === 'string' ? { freeTradeNo: decrypted.FreeTradeNo } : {}),
+          ticketTradeNo: String(decrypted.TicketTradeNo ?? ''),
+          ticketNo: String(decrypted.TicketNo ?? ''),
+          useStatus: parseTicketUseStatus(Number(decrypted.UseStatus ?? 1)),
+          raw: decrypted,
+        };
+
+        this.emitter.emit(ECPayTicketEvents.TICKET_USE_STATUS_CHANGED, notification);
+      }
+
+      res.writeHead(200, { 'Content-Type': 'text/plain' });
+      res.end('1|OK');
+    });
+  }
+}

--- a/packages/payments-adapter-ecpay/src/ecpay-ticket-gateway.ts
+++ b/packages/payments-adapter-ecpay/src/ecpay-ticket-gateway.ts
@@ -54,6 +54,7 @@ export class ECPayTicketGateway {
 
   private readonly pollIntervalMs: number;
   private readonly pollTimeoutMs: number;
+  private readonly backgroundPollingEnabled: boolean;
 
   private readonly issuedTicketsCache: IssuedTicketsCache;
 
@@ -76,8 +77,12 @@ export class ECPayTicketGateway {
     this.baseUrl = options?.baseUrl ?? this.baseUrl;
     this.platformId = options?.platformId;
 
-    this.pollIntervalMs = options?.issuePoll?.intervalMs ?? DEFAULT_POLL_INTERVAL_MS;
-    this.pollTimeoutMs = options?.issuePoll?.timeoutMs ?? DEFAULT_POLL_TIMEOUT_MS;
+    this.backgroundPollingEnabled = options?.issuePoll !== false;
+
+    const pollConfig = options?.issuePoll === false ? undefined : options?.issuePoll;
+
+    this.pollIntervalMs = pollConfig?.intervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+    this.pollTimeoutMs = pollConfig?.timeoutMs ?? DEFAULT_POLL_TIMEOUT_MS;
 
     this.serverHost = options?.serverHost ?? this.serverHost;
     this.refundNotifyPath = options?.refundNotifyPath ?? this.refundNotifyPath;
@@ -360,10 +365,12 @@ export class ECPayTicketGateway {
       });
     }
 
-    const pollingPromise = this.startBackgroundPolling(receipt.merchantTradeNo, receipt.freeTradeNo);
-
     if (input.waitForIssuance) {
-      return pollingPromise;
+      return this.startBackgroundPolling(receipt.merchantTradeNo, receipt.freeTradeNo);
+    }
+
+    if (this.backgroundPollingEnabled) {
+      void this.startBackgroundPolling(receipt.merchantTradeNo, receipt.freeTradeNo);
     }
 
     return receipt;

--- a/packages/payments-adapter-ecpay/src/ecpay-ticket-gateway.ts
+++ b/packages/payments-adapter-ecpay/src/ecpay-ticket-gateway.ts
@@ -77,6 +77,18 @@ export class ECPayTicketGateway {
     this.baseUrl = options?.baseUrl ?? this.baseUrl;
     this.platformId = options?.platformId;
 
+    if (Buffer.byteLength(this.hashKey, 'utf8') !== 16) {
+      throw new Error(
+        `[ECPayTicketGateway] hashKey must be exactly 16 bytes (ASCII) for AES-128-CBC; got ${Buffer.byteLength(this.hashKey, 'utf8')} bytes.`,
+      );
+    }
+
+    if (Buffer.byteLength(this.hashIv, 'utf8') !== 16) {
+      throw new Error(
+        `[ECPayTicketGateway] hashIv must be exactly 16 bytes (ASCII) for AES-128-CBC; got ${Buffer.byteLength(this.hashIv, 'utf8')} bytes.`,
+      );
+    }
+
     this.backgroundPollingEnabled = options?.issuePoll !== false;
 
     const pollConfig = options?.issuePoll === false ? undefined : options?.issuePoll;
@@ -162,7 +174,9 @@ export class ECPayTicketGateway {
 
   private async postEnvelope<TBody, TDecrypted>(path: string, body: TBody): Promise<TDecrypted> {
     if (!this.isGatewayReady) {
-      throw new Error('Please waiting gateway ready');
+      throw new Error(
+        '[ECPayTicketGateway] Gateway is not ready yet. Wait for the SERVER_LISTENED event before calling API methods.',
+      );
     }
 
     const encryptedData = this.encrypt<TBody>(body);
@@ -192,7 +206,9 @@ export class ECPayTicketGateway {
   private parseDateYMD(s?: string): Date | undefined {
     if (!s) return undefined;
 
-    return DateTime.fromFormat(s, 'yyyyMMdd').toJSDate();
+    const dt = DateTime.fromFormat(s, 'yyyyMMdd');
+
+    return dt.isValid ? dt.toJSDate() : undefined;
   }
 
   private parseTimestamp(s?: string): Date | undefined {
@@ -434,6 +450,11 @@ export class ECPayTicketGateway {
       throw new Error(`Unknown ECPay ticket TicketType: ${raw.TicketType}`);
     }
 
+    const startDate = this.parseDateYMD(raw.StartDate);
+    const writeOffDate = this.parseDateYMD(raw.WriteOffDate);
+    const refundDate = this.parseDateYMD(raw.RefundDate);
+    const expiredDate = this.parseDateYMD(raw.ExpiredDate);
+
     return {
       ticketNo: raw.TicketNo,
       useStatus: parseTicketUseStatus(raw.UseStatus),
@@ -441,15 +462,18 @@ export class ECPayTicketGateway {
       ...(raw.ItemName ? { itemName: raw.ItemName } : {}),
       ticketType,
       ticketAmount: raw.TicketAmount,
-      ...(this.parseDateYMD(raw.StartDate) ? { startDate: this.parseDateYMD(raw.StartDate) } : {}),
-      ...(this.parseDateYMD(raw.WriteOffDate) ? { writeOffDate: this.parseDateYMD(raw.WriteOffDate) } : {}),
-      ...(this.parseDateYMD(raw.RefundDate) ? { refundDate: this.parseDateYMD(raw.RefundDate) } : {}),
-      ...(this.parseDateYMD(raw.ExpiredDate) ? { expiredDate: this.parseDateYMD(raw.ExpiredDate) } : {}),
+      ...(startDate ? { startDate } : {}),
+      ...(writeOffDate ? { writeOffDate } : {}),
+      ...(refundDate ? { refundDate } : {}),
+      ...(expiredDate ? { expiredDate } : {}),
       ...(raw.WriteOffNo ? { writeOffNo: raw.WriteOffNo } : {}),
     };
   }
 
   private mapOrderInfo(decrypted: ECPayTicketQueryOrderInfoResponseDecrypted): ECPayTicketOrderInfo {
+    const issueDate = this.parseTimestamp(decrypted.IssueDate);
+    const escrowExpiredDate = this.parseDateYMD(decrypted.EscrowExpiredDate);
+
     return {
       ...(decrypted.MerchantTradeNo ? { merchantTradeNo: decrypted.MerchantTradeNo } : {}),
       ...(decrypted.FreeTradeNo ? { freeTradeNo: decrypted.FreeTradeNo } : {}),
@@ -459,7 +483,7 @@ export class ECPayTicketGateway {
       ...(decrypted.CreditTradeID !== undefined ? { creditTradeId: decrypted.CreditTradeID } : {}),
       status: decrypted.Status,
       remark: decrypted.Remark,
-      ...(this.parseTimestamp(decrypted.IssueDate) ? { issueDate: this.parseTimestamp(decrypted.IssueDate) } : {}),
+      ...(issueDate ? { issueDate } : {}),
       issueType: decrypted.IssueType,
       ...(decrypted.PrintType ? { printType: decrypted.PrintType } : {}),
       customer: {
@@ -467,9 +491,7 @@ export class ECPayTicketGateway {
         ...(decrypted.CustomerPhone ? { phone: decrypted.CustomerPhone } : {}),
         ...(decrypted.CustomerEmail ? { email: decrypted.CustomerEmail } : {}),
       },
-      ...(this.parseDateYMD(decrypted.EscrowExpiredDate)
-        ? { escrowExpiredDate: this.parseDateYMD(decrypted.EscrowExpiredDate) }
-        : {}),
+      ...(escrowExpiredDate ? { escrowExpiredDate } : {}),
       totalCount: decrypted.TotalCount,
       tradeAmount: decrypted.TradeAmount,
       redeemCount: decrypted.RedeemCount,
@@ -494,11 +516,24 @@ export class ECPayTicketGateway {
     this._server.listen(port, '0.0.0.0', async () => {
       if (useNgrok) {
         if (!process.env.NGROK_AUTHTOKEN) {
-          throw new Error('[ECPayTicketGateway] NGROK_AUTHTOKEN is not set.');
+          debugTicket('[ECPayTicketGateway] NGROK_AUTHTOKEN is not set. Please set it in your environment variables.');
+
+          throw new Error(
+            '[ECPayTicketGateway] NGROK_AUTHTOKEN is not set. Please set it in your environment variables.',
+          );
         }
 
-        const ngrokModule = await import('@ngrok/ngrok');
-        const ngrok = ngrokModule.default;
+        try {
+          await import('@ngrok/ngrok');
+        } catch (ex) {
+          debugTicket(
+            '[ECPayTicketGateway] Failed to import @ngrok/ngrok. Please install it (npm i @ngrok/ngrok) to use the ngrok tunnel feature.',
+          );
+
+          throw ex;
+        }
+
+        const ngrok = (await import('@ngrok/ngrok')).default;
 
         await ngrok.authtoken(process.env.NGROK_AUTHTOKEN);
 
@@ -528,14 +563,52 @@ export class ECPayTicketGateway {
     }
   }
 
+  private requireStringField(decrypted: Record<string, unknown>, field: string): string {
+    const value = decrypted[field];
+
+    if (typeof value !== 'string' || value.length === 0) {
+      throw new ECPayTicketCallbackError('INVALID_PAYLOAD', `Missing or invalid string field: ${field}`);
+    }
+
+    return value;
+  }
+
+  private requireNumericField(decrypted: Record<string, unknown>, field: string): number {
+    const value = decrypted[field];
+
+    if (typeof value === 'number' && Number.isFinite(value)) {
+      return value;
+    }
+
+    if (typeof value === 'string' && value.length > 0) {
+      const parsed = Number(value);
+
+      if (Number.isFinite(parsed)) {
+        return parsed;
+      }
+    }
+
+    throw new ECPayTicketCallbackError('INVALID_PAYLOAD', `Missing or invalid numeric field: ${field}`);
+  }
+
   public handleRefundNotification(envelope: ECPayTicketResponseEnvelope): ECPayTicketRefundNotification {
     const decrypted = this.parseAndVerifyEnvelope(envelope);
+
+    const ticketTradeNo = this.requireStringField(decrypted, 'TicketTradeNo');
+    const refundAmount = this.requireNumericField(decrypted, 'RefundAmount');
+
+    if (typeof decrypted.MerchantTradeNo !== 'string' && typeof decrypted.FreeTradeNo !== 'string') {
+      throw new ECPayTicketCallbackError(
+        'INVALID_PAYLOAD',
+        'Either MerchantTradeNo or FreeTradeNo must be present in the callback payload',
+      );
+    }
 
     const notification: ECPayTicketRefundNotification = {
       ...(typeof decrypted.MerchantTradeNo === 'string' ? { merchantTradeNo: decrypted.MerchantTradeNo } : {}),
       ...(typeof decrypted.FreeTradeNo === 'string' ? { freeTradeNo: decrypted.FreeTradeNo } : {}),
-      ticketTradeNo: String(decrypted.TicketTradeNo ?? ''),
-      refundAmount: Number(decrypted.RefundAmount ?? 0),
+      ticketTradeNo,
+      refundAmount,
       ...(typeof decrypted.Remark === 'string' ? { remark: decrypted.Remark } : {}),
       raw: decrypted,
     };
@@ -548,12 +621,31 @@ export class ECPayTicketGateway {
   public handleUseStatusNotification(envelope: ECPayTicketResponseEnvelope): ECPayTicketUseStatusNotification {
     const decrypted = this.parseAndVerifyEnvelope(envelope);
 
+    const ticketTradeNo = this.requireStringField(decrypted, 'TicketTradeNo');
+    const ticketNo = this.requireStringField(decrypted, 'TicketNo');
+    const useStatusCode = this.requireNumericField(decrypted, 'UseStatus');
+
+    let useStatus: ECPayTicketUseStatusNotification['useStatus'];
+
+    try {
+      useStatus = parseTicketUseStatus(useStatusCode);
+    } catch {
+      throw new ECPayTicketCallbackError('INVALID_PAYLOAD', `Unknown UseStatus code: ${useStatusCode}`);
+    }
+
+    if (typeof decrypted.MerchantTradeNo !== 'string' && typeof decrypted.FreeTradeNo !== 'string') {
+      throw new ECPayTicketCallbackError(
+        'INVALID_PAYLOAD',
+        'Either MerchantTradeNo or FreeTradeNo must be present in the callback payload',
+      );
+    }
+
     const notification: ECPayTicketUseStatusNotification = {
       ...(typeof decrypted.MerchantTradeNo === 'string' ? { merchantTradeNo: decrypted.MerchantTradeNo } : {}),
       ...(typeof decrypted.FreeTradeNo === 'string' ? { freeTradeNo: decrypted.FreeTradeNo } : {}),
-      ticketTradeNo: String(decrypted.TicketTradeNo ?? ''),
-      ticketNo: String(decrypted.TicketNo ?? ''),
-      useStatus: parseTicketUseStatus(Number(decrypted.UseStatus ?? 1)),
+      ticketTradeNo,
+      ticketNo,
+      useStatus,
       raw: decrypted,
     };
 
@@ -600,7 +692,15 @@ export class ECPayTicketGateway {
       } catch (error) {
         if (error instanceof ECPayTicketCallbackError) {
           res.writeHead(400);
-          res.end(`0|${error.code === 'INVALID_CHECKMAC' ? 'InvalidCheckMacValue' : 'InvalidData'}`);
+
+          const tag =
+            error.code === 'INVALID_CHECKMAC'
+              ? 'InvalidCheckMacValue'
+              : error.code === 'INVALID_PAYLOAD'
+                ? 'InvalidPayload'
+                : 'InvalidData';
+
+          res.end(`0|${tag}`);
 
           return;
         }
@@ -612,7 +712,7 @@ export class ECPayTicketGateway {
   }
 }
 
-export type ECPayTicketCallbackErrorCode = 'INVALID_CHECKMAC' | 'INVALID_DATA';
+export type ECPayTicketCallbackErrorCode = 'INVALID_CHECKMAC' | 'INVALID_DATA' | 'INVALID_PAYLOAD';
 
 export class ECPayTicketCallbackError extends Error {
   public readonly code: ECPayTicketCallbackErrorCode;

--- a/packages/payments-adapter-ecpay/src/ecpay-ticket-gateway.ts
+++ b/packages/payments-adapter-ecpay/src/ecpay-ticket-gateway.ts
@@ -508,6 +508,53 @@ export class ECPayTicketGateway {
     });
   }
 
+  private parseAndVerifyEnvelope(envelope: ECPayTicketResponseEnvelope): Record<string, unknown> {
+    if (!this.verifyResponseEnvelope(envelope)) {
+      debugTicket('Invalid CheckMacValue on callback');
+      throw new ECPayTicketCallbackError('INVALID_CHECKMAC', 'Invalid CheckMacValue');
+    }
+
+    try {
+      return this.decrypt<Record<string, unknown>>(envelope.Data);
+    } catch {
+      throw new ECPayTicketCallbackError('INVALID_DATA', 'Failed to decrypt Data');
+    }
+  }
+
+  public handleRefundNotification(envelope: ECPayTicketResponseEnvelope): ECPayTicketRefundNotification {
+    const decrypted = this.parseAndVerifyEnvelope(envelope);
+
+    const notification: ECPayTicketRefundNotification = {
+      ...(typeof decrypted.MerchantTradeNo === 'string' ? { merchantTradeNo: decrypted.MerchantTradeNo } : {}),
+      ...(typeof decrypted.FreeTradeNo === 'string' ? { freeTradeNo: decrypted.FreeTradeNo } : {}),
+      ticketTradeNo: String(decrypted.TicketTradeNo ?? ''),
+      refundAmount: Number(decrypted.RefundAmount ?? 0),
+      ...(typeof decrypted.Remark === 'string' ? { remark: decrypted.Remark } : {}),
+      raw: decrypted,
+    };
+
+    this.emitter.emit(ECPayTicketEvents.TICKET_REFUND_NOTIFIED, notification);
+
+    return notification;
+  }
+
+  public handleUseStatusNotification(envelope: ECPayTicketResponseEnvelope): ECPayTicketUseStatusNotification {
+    const decrypted = this.parseAndVerifyEnvelope(envelope);
+
+    const notification: ECPayTicketUseStatusNotification = {
+      ...(typeof decrypted.MerchantTradeNo === 'string' ? { merchantTradeNo: decrypted.MerchantTradeNo } : {}),
+      ...(typeof decrypted.FreeTradeNo === 'string' ? { freeTradeNo: decrypted.FreeTradeNo } : {}),
+      ticketTradeNo: String(decrypted.TicketTradeNo ?? ''),
+      ticketNo: String(decrypted.TicketNo ?? ''),
+      useStatus: parseTicketUseStatus(Number(decrypted.UseStatus ?? 1)),
+      raw: decrypted,
+    };
+
+    this.emitter.emit(ECPayTicketEvents.TICKET_USE_STATUS_CHANGED, notification);
+
+    return notification;
+  }
+
   public async defaultServerListener(req: IncomingMessage, res: ServerResponse): Promise<void> {
     if (!req.url || req.method !== 'POST' || !~[this.refundNotifyPath, this.useStatusNotifyPath].indexOf(req.url)) {
       res.writeHead(404);
@@ -534,51 +581,38 @@ export class ECPayTicketGateway {
         return;
       }
 
-      if (!this.verifyResponseEnvelope(envelope)) {
-        debugTicket('Invalid CheckMacValue on callback');
-        res.writeHead(400);
-        res.end('0|InvalidCheckMacValue');
-
-        return;
-      }
-
-      let decrypted: Record<string, unknown>;
-
       try {
-        decrypted = this.decrypt<Record<string, unknown>>(envelope.Data);
-      } catch {
-        res.writeHead(400);
-        res.end('0|InvalidData');
+        if (req.url === this.refundNotifyPath) {
+          this.handleRefundNotification(envelope);
+        } else {
+          this.handleUseStatusNotification(envelope);
+        }
 
-        return;
+        res.writeHead(200, { 'Content-Type': 'text/plain' });
+        res.end('1|OK');
+      } catch (error) {
+        if (error instanceof ECPayTicketCallbackError) {
+          res.writeHead(400);
+          res.end(`0|${error.code === 'INVALID_CHECKMAC' ? 'InvalidCheckMacValue' : 'InvalidData'}`);
+
+          return;
+        }
+
+        res.writeHead(500);
+        res.end('0|InternalError');
       }
-
-      if (req.url === this.refundNotifyPath) {
-        const notification: ECPayTicketRefundNotification = {
-          ...(typeof decrypted.MerchantTradeNo === 'string' ? { merchantTradeNo: decrypted.MerchantTradeNo } : {}),
-          ...(typeof decrypted.FreeTradeNo === 'string' ? { freeTradeNo: decrypted.FreeTradeNo } : {}),
-          ticketTradeNo: String(decrypted.TicketTradeNo ?? ''),
-          refundAmount: Number(decrypted.RefundAmount ?? 0),
-          ...(typeof decrypted.Remark === 'string' ? { remark: decrypted.Remark } : {}),
-          raw: decrypted,
-        };
-
-        this.emitter.emit(ECPayTicketEvents.TICKET_REFUND_NOTIFIED, notification);
-      } else {
-        const notification: ECPayTicketUseStatusNotification = {
-          ...(typeof decrypted.MerchantTradeNo === 'string' ? { merchantTradeNo: decrypted.MerchantTradeNo } : {}),
-          ...(typeof decrypted.FreeTradeNo === 'string' ? { freeTradeNo: decrypted.FreeTradeNo } : {}),
-          ticketTradeNo: String(decrypted.TicketTradeNo ?? ''),
-          ticketNo: String(decrypted.TicketNo ?? ''),
-          useStatus: parseTicketUseStatus(Number(decrypted.UseStatus ?? 1)),
-          raw: decrypted,
-        };
-
-        this.emitter.emit(ECPayTicketEvents.TICKET_USE_STATUS_CHANGED, notification);
-      }
-
-      res.writeHead(200, { 'Content-Type': 'text/plain' });
-      res.end('1|OK');
     });
+  }
+}
+
+export type ECPayTicketCallbackErrorCode = 'INVALID_CHECKMAC' | 'INVALID_DATA';
+
+export class ECPayTicketCallbackError extends Error {
+  public readonly code: ECPayTicketCallbackErrorCode;
+
+  constructor(code: ECPayTicketCallbackErrorCode, message: string) {
+    super(message);
+    this.name = 'ECPayTicketCallbackError';
+    this.code = code;
   }
 }

--- a/packages/payments-adapter-ecpay/src/ecpay-ticket-typings.ts
+++ b/packages/payments-adapter-ecpay/src/ecpay-ticket-typings.ts
@@ -1,0 +1,364 @@
+import { IncomingMessage, ServerResponse } from 'http';
+
+export enum ECPayTicketBaseUrls {
+  DEVELOPMENT = 'https://ecticket-stage.ecpay.com.tw',
+  PRODUCTION = 'https://ecticket.ecpay.com.tw',
+}
+
+export enum ECPayTicketEvents {
+  TICKET_ISSUED = 'TICKET_ISSUED',
+  TICKET_ISSUE_FAILED = 'TICKET_ISSUE_FAILED',
+  TICKET_REFUND_NOTIFIED = 'TICKET_REFUND_NOTIFIED',
+  TICKET_USE_STATUS_CHANGED = 'TICKET_USE_STATUS_CHANGED',
+  SERVER_LISTENED = 'SERVER_LISTENED',
+}
+
+export enum ECPayIssueType {
+  CVS = '1',
+  PAPER = '2',
+  ELECTRONIC = '3',
+  SERIAL_ONLY = '4',
+}
+
+export enum ECPayPrintType {
+  ECPAY = '1',
+  MERCHANT = '2',
+}
+
+export enum ECPayIsImmediate {
+  IMMEDIATE = '1',
+  SCHEDULED = '2',
+}
+
+export enum ECPayTicketIssueStatusCode {
+  SUCCESS = 1,
+  FAILED = 2,
+  PROCESSING = 3,
+}
+
+export enum ECPayTicketUseStatus {
+  UNUSED = 'unused',
+  REDEEMED = 'redeemed',
+  REFUNDED = 'refunded',
+  EXPIRED = 'expired',
+}
+
+const TICKET_USE_STATUS_MAP: Record<number, ECPayTicketUseStatus> = {
+  1: ECPayTicketUseStatus.UNUSED,
+  2: ECPayTicketUseStatus.REDEEMED,
+  3: ECPayTicketUseStatus.REFUNDED,
+  4: ECPayTicketUseStatus.EXPIRED,
+};
+
+export function parseTicketUseStatus(code: number): ECPayTicketUseStatus {
+  const mapped = TICKET_USE_STATUS_MAP[code];
+
+  if (!mapped) {
+    throw new Error(`Unknown ECPay ticket UseStatus code: ${code}`);
+  }
+
+  return mapped;
+}
+
+export enum ECPayTicketType {
+  REDEMPTION = 'redemption',
+  GIFT = 'gift',
+}
+
+export interface IssuedTicketRecord {
+  merchantTradeNo?: string;
+  freeTradeNo?: string;
+  issueType: ECPayIssueType;
+  ticketTradeNo?: string;
+  issuedAt: Date;
+}
+
+export interface IssuedTicketsCache {
+  get(key: string): Promise<IssuedTicketRecord | undefined>;
+  set(key: string, value: IssuedTicketRecord): Promise<void>;
+}
+
+export interface ECPayTicketGatewayOptions {
+  merchantId?: string;
+  hashKey?: string;
+  hashIv?: string;
+  baseUrl?: ECPayTicketBaseUrls | string;
+  platformId?: string;
+
+  issuePoll?: {
+    intervalMs?: number;
+    timeoutMs?: number;
+  };
+
+  issuedTicketsCache?: IssuedTicketsCache;
+  issuedTicketsCacheTTL?: number;
+
+  withServer?: boolean | 'ngrok';
+  serverHost?: string;
+  refundNotifyPath?: string;
+  useStatusNotifyPath?: string;
+  onServerListen?: () => void;
+  serverListener?: (req: IncomingMessage, res: ServerResponse) => void;
+}
+
+export interface ECPayTicketItemInput {
+  itemNo?: string;
+  itemName?: string;
+  ticketPrice?: number;
+  ticketAmount: number;
+  startDate?: Date;
+  expireDate?: Date;
+}
+
+export interface ECPayTicketIssueInput {
+  merchantTradeNo?: string;
+  freeTradeNo?: string;
+  issueType: ECPayIssueType;
+  printType?: ECPayPrintType;
+  isImmediate?: ECPayIsImmediate;
+  operator: string;
+  storeId?: string;
+  customer?: {
+    name?: string;
+    phone?: string;
+    email?: string;
+    address?: string;
+  };
+  refundNotifyUrl?: string;
+  useStatusNotifyUrl?: string;
+  tickets: ECPayTicketItemInput[];
+  /**
+   * 若為 true，issue() 會等候背景輪詢完成才 resolve；
+   * 否則立即回傳 receipt，最終結果以 event 通知。
+   */
+  waitForIssuance?: boolean;
+}
+
+export interface ECPayTicketIssueReceipt {
+  merchantTradeNo?: string;
+  freeTradeNo?: string;
+  ticketTradeNo: string;
+  tickets: Array<{
+    itemNo?: string;
+    itemName?: string;
+    ticketPrice?: number;
+    ticketAmount: number;
+  }>;
+}
+
+export type ECPayTicketIssueOutcome =
+  | {
+      status: 'success';
+      merchantTradeNo?: string;
+      freeTradeNo?: string;
+    }
+  | {
+      status: 'failed';
+      merchantTradeNo?: string;
+      freeTradeNo?: string;
+      remark: string;
+    }
+  | {
+      status: 'processing';
+      merchantTradeNo?: string;
+      freeTradeNo?: string;
+    };
+
+export interface ECPayTicketInfo {
+  ticketNo: string;
+  useStatus: ECPayTicketUseStatus;
+  itemNo?: string;
+  itemName?: string;
+  ticketType: ECPayTicketType;
+  ticketAmount: number;
+  startDate?: Date;
+  writeOffDate?: Date;
+  refundDate?: Date;
+  expiredDate?: Date;
+  writeOffNo?: string;
+}
+
+export interface ECPayTicketOrderInfo {
+  merchantTradeNo?: string;
+  freeTradeNo?: string;
+  ticketTradeNo: string;
+  paymentProvider: string;
+  paymentType: string;
+  creditTradeId?: number;
+  status: ECPayTicketIssueStatusCode;
+  remark: string;
+  issueDate?: Date;
+  issueType: ECPayIssueType;
+  printType?: ECPayPrintType;
+  customer: {
+    name?: string;
+    phone?: string;
+    email?: string;
+  };
+  escrowExpiredDate?: Date;
+  totalCount: number;
+  tradeAmount: number;
+  redeemCount: number;
+  redeemAmount: number;
+  refundCount: number;
+  refundAmount: number;
+  totalRefundFee: number;
+  unUsedCount: number;
+  unUsedAmount: number;
+  expiredCount: number;
+  tickets: ECPayTicketInfo[];
+}
+
+export interface ECPayTicketRefundNotification {
+  merchantTradeNo?: string;
+  freeTradeNo?: string;
+  ticketTradeNo: string;
+  refundAmount: number;
+  remark?: string;
+  raw: Record<string, unknown>;
+}
+
+export interface ECPayTicketUseStatusNotification {
+  merchantTradeNo?: string;
+  freeTradeNo?: string;
+  ticketTradeNo: string;
+  ticketNo: string;
+  useStatus: ECPayTicketUseStatus;
+  raw: Record<string, unknown>;
+}
+
+/* ------- Wire-level (request/response body) types ------- */
+
+export interface ECPayTicketRequestEnvelope {
+  PlatformID?: string;
+  MerchantID: string;
+  RqHeader: {
+    Timestamp: number;
+  };
+  Data: string;
+  CheckMacValue: string;
+}
+
+export interface ECPayTicketResponseEnvelope {
+  PlatformID?: string;
+  MerchantID: string;
+  RpHeader: {
+    Timestamp: number;
+  };
+  TransCode: number;
+  TransMsg: string;
+  Data: string;
+  CheckMacValue: string;
+}
+
+export interface ECPayTicketItemRequestBody {
+  ItemNo?: string;
+  ItemName?: string;
+  TicketPrice?: number;
+  TicketAmount: number;
+  StartDate?: string;
+  ExpireDate?: string;
+}
+
+export interface ECPayTicketIssueRequestBody {
+  MerchantID: string;
+  MerchantTradeNo?: string;
+  FreeTradeNo?: string;
+  IssueType: ECPayIssueType;
+  PrintType?: ECPayPrintType;
+  IsImmediate?: ECPayIsImmediate;
+  RefundNotifyURL?: string;
+  UseStatusNotifyURL?: string;
+  StoreID?: string;
+  Operator: string;
+  CustomerName?: string;
+  CustomerPhone?: string;
+  CustomerEmail?: string;
+  CustomerAddress?: string;
+  TicketInfo: ECPayTicketItemRequestBody[];
+}
+
+export interface ECPayTicketIssueResponseDecrypted {
+  RtnCode: number;
+  RtnMsg: string;
+  MerchantTradeNo?: string;
+  FreeTradeNo?: string;
+  TicketTradeNo: string;
+  TicketData: Array<{
+    ItemNo?: string;
+    ItemName?: string;
+    TicketPrice?: number;
+    TicketAmount: number;
+  }>;
+}
+
+export interface ECPayTicketQueryIssueResultRequestBody {
+  MerchantID: string;
+  MerchantTradeNo?: string;
+  FreeTradeNo?: string;
+}
+
+export interface ECPayTicketQueryIssueResultResponseDecrypted {
+  RtnCode: number;
+  RtnMsg: string;
+  MerchantTradeNo?: string;
+  FreeTradeNo?: string;
+  Status: ECPayTicketIssueStatusCode;
+  Remark: string;
+}
+
+export interface ECPayTicketQueryOrderInfoRequestBody {
+  MerchantID: string;
+  MerchantTradeNo?: string;
+  FreeTradeNo?: string;
+  PageNum?: number;
+}
+
+export interface ECPayTicketListResponseItem {
+  TicketNo: string;
+  UseStatus: number;
+  ItemNo?: string;
+  ItemName?: string;
+  TicketType: string;
+  TicketAmount: number;
+  StartDate?: string;
+  WriteOffDate?: string;
+  RefundDate?: string;
+  ExpiredDate?: string;
+  WriteOffNo?: string;
+}
+
+export interface ECPayTicketQueryOrderInfoResponseDecrypted {
+  RtnCode: number;
+  RtnMsg: string;
+  MerchantID: string;
+  MerchantTradeNo?: string;
+  FreeTradeNo?: string;
+  TicketTradeNo: string;
+  PaymentProvider: string;
+  PaymentType: string;
+  CreditTradeID?: number;
+  Status: ECPayTicketIssueStatusCode;
+  Remark: string;
+  IssueDate?: string;
+  IssueType: ECPayIssueType;
+  PrintType?: ECPayPrintType;
+  CustomerName?: string;
+  CustomerPhone?: string;
+  CustomerEmail?: string;
+  EscrowExpiredDate?: string;
+  TotalCount: number;
+  TradeAmount: number;
+  RedeemCount: number;
+  RedeemAmount: number;
+  RefundCount: number;
+  RefundAmount: number;
+  TotalRefundFee: number;
+  UnUsedCount: number;
+  UnUsedAmount: number;
+  ExpiredCount: number;
+  TicketList: ECPayTicketListResponseItem[];
+}
+
+export const ECPAY_TICKET_TRANS_CODE_SUCCESS = 1;
+export const ECPAY_TICKET_RTN_CODE_SUCCESS = 1;

--- a/packages/payments-adapter-ecpay/src/ecpay-ticket-typings.ts
+++ b/packages/payments-adapter-ecpay/src/ecpay-ticket-typings.ts
@@ -85,10 +85,24 @@ export interface ECPayTicketGatewayOptions {
   baseUrl?: ECPayTicketBaseUrls | string;
   platformId?: string;
 
-  issuePoll?: {
-    intervalMs?: number;
-    timeoutMs?: number;
-  };
+  /**
+   * Background-polling configuration for `issue()`.
+   *
+   * - `undefined` (default) — gateway polls every 30s up to 6min after `issue()`
+   *   resolves, then emits `TICKET_ISSUED` or `TICKET_ISSUE_FAILED`.
+   * - `{ intervalMs, timeoutMs }` — override the defaults.
+   * - `false` — disable background polling entirely. `issue()` returns the
+   *   receipt and does NOT emit issuance events. You must drive polling
+   *   yourself by calling `queryIssueResult()`. `waitForIssuance: true` still
+   *   works per call (it triggers a one-shot poll loop using the default
+   *   interval/timeout regardless of this setting).
+   */
+  issuePoll?:
+    | false
+    | {
+        intervalMs?: number;
+        timeoutMs?: number;
+      };
 
   issuedTicketsCache?: IssuedTicketsCache;
   issuedTicketsCacheTTL?: number;

--- a/packages/payments-adapter-ecpay/src/ecpay-utils.ts
+++ b/packages/payments-adapter-ecpay/src/ecpay-utils.ts
@@ -1,0 +1,9 @@
+import { createHash } from 'crypto';
+
+export function ecpayUrlEncode(raw: string): string {
+  return encodeURIComponent(raw).toLowerCase().replace(/'/g, '%27').replace(/~/g, '%7e').replace(/%20/g, '+');
+}
+
+export function ecpaySha256(raw: string): string {
+  return createHash('sha256').update(raw).digest('hex').toUpperCase();
+}

--- a/packages/payments-adapter-ecpay/src/index.ts
+++ b/packages/payments-adapter-ecpay/src/index.ts
@@ -27,7 +27,8 @@ export { ECPayPayment } from './ecpay-payment';
 export { ECPayOrder } from './ecpay-order';
 export { ECPayOrderItem } from './ecpay-order-item';
 export { ECPayBindCardRequest } from './ecpay-bind-card-request';
-export { ECPayTicketGateway } from './ecpay-ticket-gateway';
+export { ECPayTicketGateway, ECPayTicketCallbackError } from './ecpay-ticket-gateway';
+export type { ECPayTicketCallbackErrorCode } from './ecpay-ticket-gateway';
 
 export {
   ECPayTicketBaseUrls,
@@ -51,6 +52,8 @@ export type {
   ECPayTicketInfo,
   ECPayTicketRefundNotification,
   ECPayTicketUseStatusNotification,
+  ECPayTicketResponseEnvelope,
+  ECPayTicketRequestEnvelope,
   IssuedTicketsCache,
   IssuedTicketRecord,
 } from './ecpay-ticket-typings';

--- a/packages/payments-adapter-ecpay/src/index.ts
+++ b/packages/payments-adapter-ecpay/src/index.ts
@@ -27,5 +27,32 @@ export { ECPayPayment } from './ecpay-payment';
 export { ECPayOrder } from './ecpay-order';
 export { ECPayOrderItem } from './ecpay-order-item';
 export { ECPayBindCardRequest } from './ecpay-bind-card-request';
+export { ECPayTicketGateway } from './ecpay-ticket-gateway';
+
+export {
+  ECPayTicketBaseUrls,
+  ECPayTicketEvents,
+  ECPayIssueType,
+  ECPayPrintType,
+  ECPayIsImmediate,
+  ECPayTicketIssueStatusCode,
+  ECPayTicketUseStatus,
+  ECPayTicketType,
+  parseTicketUseStatus,
+} from './ecpay-ticket-typings';
+
+export type {
+  ECPayTicketGatewayOptions,
+  ECPayTicketIssueInput,
+  ECPayTicketItemInput,
+  ECPayTicketIssueReceipt,
+  ECPayTicketIssueOutcome,
+  ECPayTicketOrderInfo,
+  ECPayTicketInfo,
+  ECPayTicketRefundNotification,
+  ECPayTicketUseStatusNotification,
+  IssuedTicketsCache,
+  IssuedTicketRecord,
+} from './ecpay-ticket-typings';
 
 export * from '@rytass/payments';


### PR DESCRIPTION
## Summary

- Adds `ECPayTicketGateway`, a standalone gateway for ECPay's ECTicket product line — issue, query issuance result, query order info (with per-ticket usage list).
- Implements the JSON+AES-128-CBC envelope + SHA256 `CheckMacValue` signing scheme used by `ecticket.ecpay.com.tw`, separate from the form/querystring scheme used by `ECPayPayment`.
- Provides both transport choices for refund / use-status push callbacks: a built-in HTTP server (mounts the URLs automatically) and framework-agnostic handlers that take an already-parsed envelope, so callers using Express / NestJS / Fastify never touch raw Node `IncomingMessage`/`ServerResponse`.
- Extracts a shared `ecpayUrlEncode` / `ecpaySha256` helper (`src/ecpay-utils.ts`) so the existing `ECPayPayment.addMac()` and the new ticket signing logic share the same URL-encoding contract.

## What's new

| Capability | API |
|---|---|
| Issue tickets (CVS / paper / electronic / serial-only) | `ticket.issue(input)` — returns receipt immediately, background polling emits `TICKET_ISSUED` / `TICKET_ISSUE_FAILED` |
| Block until issuance settles | `ticket.issue({ ...input, waitForIssuance: true })` |
| Manual issuance result lookup | `ticket.queryIssueResult({ merchantTradeNo })` |
| Full order detail + per-ticket usage | `ticket.queryOrderInfo({ merchantTradeNo, pageNum? })` |
| Refund / use-status callbacks (built-in server) | `withServer: true` mounts `/payments/ecpay/ticket/{refund,use-status}` and emits `TICKET_REFUND_NOTIFIED` / `TICKET_USE_STATUS_CHANGED` |
| Refund / use-status callbacks (framework-agnostic) | `ticket.handleRefundNotification(envelope)` / `ticket.handleUseStatusNotification(envelope)` — verify CheckMacValue, decrypt, emit, return typed notification; throw `ECPayTicketCallbackError` on failure |

## Files

- `src/ecpay-ticket-gateway.ts` — new gateway class
- `src/ecpay-ticket-typings.ts` — wire-level + domain types, enums, mapping helpers
- `src/ecpay-utils.ts` — shared URL-encode + SHA256 helpers
- `src/ecpay-payment.ts` — `addMac()` rewired to shared helper (no behaviour change)
- `src/index.ts` — exports new symbols
- `__utils__/ticket-envelope.ts` — test-side encryption / CheckMacValue helpers
- `__tests__/ecpay-ticket-gateway.spec.ts` — 25 new tests
- `README.md` — usage docs for the new gateway (including framework-agnostic callback section)

## Test plan

- [x] `npx nx test payments-adapter-ecpay` — 165 tests pass (140 existing + 25 new)
- [x] `npx nx lint payments-adapter-ecpay` — clean
- [x] `npx nx build payments-adapter-ecpay` — type-checked + bundled
- [ ] Smoke test against ECPay ECTicket sandbox with real credentials (not exercised in CI; tester must use sandbox account)

## Follow-up worth considering

The existing `ECPayPayment` has the same framework-agnostic gap as the ticket gateway used to: `handlePaymentResult` / `handleAsyncInformation` / `handleBindCardResult` are public but require the caller to verify `CheckMacValue` (the `checkMac()` helper is `private`) and look up the Order/BindCardRequest from cache themselves. The only clean entry point is `defaultServerListener(req, res)`, which is tied to Node's raw `http` types. Adding matching framework-agnostic wrappers on `ECPayPayment` (callbacks that take already-parsed urlencoded payloads, do verify+lookup+emit) is straightforward but out of scope for this PR. Happy to do it in a follow-up if reviewers agree.

## Out of scope

- Ticket redeem / refund endpoints (`/api/Ticket/UseTicket`, `/api/Ticket/RefundTicket`)
- Other query endpoints (ticket detail list, paper face data, order refund info)
- `@rytass/payments-nestjs-module` integration (current module is single-gateway)
- Sharing one HTTP server port between `ECPayPayment` and `ECPayTicketGateway`
- Framework-agnostic harmonisation for `ECPayPayment` (see Follow-up above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)