### PR TITLE
fix(payments-adapter-newebpay): include NotifyURL in prepareBindCard payload

### DIFF
--- a/packages/payments-adapter-newebpay/__tests__/bind-card.spec.ts
+++ b/packages/payments-adapter-newebpay/__tests__/bind-card.spec.ts
@@ -3,7 +3,7 @@
  */
 
 import http, { createServer, IncomingMessage, ServerResponse } from 'http';
-import { createCipheriv, createHash } from 'crypto';
+import { createCipheriv, createDecipheriv, createHash } from 'crypto';
 import { OrderState, PaymentEvents } from '@rytass/payments';
 import { NewebPayPayment } from '../src';
 
@@ -134,6 +134,31 @@ describe('NewebPay Bind Card', () => {
       });
 
       expect(request.finishRedirectURL).toBe('https://example.com/success');
+    });
+
+    it('should embed NotifyURL alongside ReturnURL so NewebPay has a server-to-server fallback when the browser ReturnURL never fires', async () => {
+      const payment = new NewebPayPayment({
+        merchantId: MERCHANT_ID,
+        aesKey: AES_KEY,
+        aesIv: AES_IV,
+        serverHost: 'https://test.rytass.com',
+        boundCardPath: '/bound-card-callback',
+      });
+
+      const request = await payment.prepareBindCard('member-notify-url');
+      const decipher = createDecipheriv('aes-256-cbc', AES_KEY, AES_IV);
+
+      decipher.setAutoPadding(false);
+
+      const plain = `${decipher.update(request.form.TradeInfo, 'hex', 'utf8')}${decipher.final('utf8')}`.replace(
+        /\p{Cc}/gu,
+        '',
+      );
+
+      const decoded = new URLSearchParams(plain);
+
+      expect(decoded.get('ReturnURL')).toBe('https://test.rytass.com/bound-card-callback');
+      expect(decoded.get('NotifyURL')).toBe('https://test.rytass.com/bound-card-callback');
     });
 
     it('should get form data and transition to PRE_COMMIT state', async () => {

--- a/packages/payments-adapter-newebpay/__tests__/bind-card.spec.ts
+++ b/packages/payments-adapter-newebpay/__tests__/bind-card.spec.ts
@@ -295,6 +295,49 @@ describe('NewebPay Bind Card', () => {
       expect(boundEventHandler).toHaveBeenCalledWith(request);
     });
 
+    it('should ignore a second bound() call so consumers do not fire CARD_BOUND twice when NewebPay delivers via both ReturnURL and NotifyURL', async () => {
+      const payment = new NewebPayPayment({
+        merchantId: MERCHANT_ID,
+        aesKey: AES_KEY,
+        aesIv: AES_IV,
+        serverHost: 'https://test.rytass.com',
+      });
+
+      const boundEventHandler = jest.fn();
+
+      payment.emitter.on(PaymentEvents.CARD_BOUND, boundEventHandler);
+
+      const request = await payment.prepareBindCard('member-bound-twice');
+
+      const firstPayload = {
+        TokenValue: 'token-first',
+        Card6No: '411111',
+        Card4No: '1111',
+        PayTime: '2025-01-10 14:30:00',
+        Exp: '2812',
+        MerchantOrderNo: request.id,
+        TradeNo: 'TN-first',
+        MerchantID: MERCHANT_ID,
+        Status: 'SUCCESS' as const,
+      };
+
+      request.bound(firstPayload);
+
+      // Simulate the second arrival (e.g. server-to-server NotifyURL after
+      // the browser ReturnURL already committed the request). A misbehaving
+      // gateway could even send a different payload — we still must not
+      // re-run side effects.
+      request.bound({
+        ...firstPayload,
+        TokenValue: 'token-second',
+        TradeNo: 'TN-second',
+      });
+
+      expect(request.state).toBe(OrderState.COMMITTED);
+      expect(request.cardId).toBe('token-first');
+      expect(boundEventHandler).toHaveBeenCalledTimes(1);
+    });
+
     it('should return correct getBindCardUrl', async () => {
       const payment = new NewebPayPayment({
         merchantId: MERCHANT_ID,

--- a/packages/payments-adapter-newebpay/src/newebpay-bind-card-request.ts
+++ b/packages/payments-adapter-newebpay/src/newebpay-bind-card-request.ts
@@ -129,6 +129,14 @@ export class NewebPayBindCardRequest implements BindCardRequest {
   }
 
   bound(payload: NewebPayBindCardResponseTradeInfoPayload): void {
+    // Idempotency: NewebPay delivers the bind-card result on *both* the
+    // browser ReturnURL POST and the server-to-server NotifyURL — by design,
+    // so the merchant has a fallback when the browser path fails. Without a
+    // state guard, the second arrival would re-run all side effects and
+    // double-emit CARD_BOUND, causing downstream listeners to charge twice,
+    // insert duplicate periods, send duplicate emails, etc.
+    if (this._state === OrderState.COMMITTED) return;
+
     this._cardId = payload.TokenValue;
     this._cardNumberPrefix = payload.Card6No;
     this._cardNumberSuffix = payload.Card4No;

--- a/packages/payments-adapter-newebpay/src/newebpay-payment.ts
+++ b/packages/payments-adapter-newebpay/src/newebpay-payment.ts
@@ -1090,6 +1090,10 @@ export class NewebPayPayment<CM extends NewebPayCommitMessage = NewebPayCommitMe
       CREDITAEAGREEMENT: 0,
       TokenTerm: memberId,
       ReturnURL: `${this.serverHost}${this.boundCardPath}`,
+      // Server-to-server fallback when the browser ReturnURL redirect
+      // never lands (tab closed, network lost, browser crash, …).
+      // Same handler path — defaultServerListener routes by URL.
+      NotifyURL: `${this.serverHost}${this.boundCardPath}`,
     } satisfies NewebPayBindCardRequestTradeInfoPayload;
 
     const request = new NewebPayBindCardRequest({


### PR DESCRIPTION
## Summary

`prepareBindCard()` only embedded `ReturnURL` in the payload sent to NewebPay, leaving the gateway with **no server-to-server fallback** when the browser ReturnURL redirect never lands (closed tab, network drop, browser crash).

We hit this on a live merchant: the cardholder's bind-card + initial charge succeeded at the gateway side (`QueryTradeInfo` → `Status: SUCCESS, TradeStatus: 1, PayTime: 2026-05-10 14:14:50`), but the consumer's `membership_payments.chargedAt` stayed NULL — the customer only noticed days later when the site still showed them as expired. NewebPay would have retried via `NotifyURL` over server-to-server IPN, but we never gave them one for bind-card requests.

The regular `prepare()` already sets `NotifyURL` next to `ReturnURL` (newebpay-payment.ts:581). `prepareBindCard()` was missed even though the typing (`NewebPayBindCardRequestTradeInfoPayload`, typings.ts:451) already permitted the field.

## Changes

**Commit 1 — wire NotifyURL into the payload.** Same URL as `ReturnURL`: the `defaultServerListener` already routes both browser POST and server IPN through the `boundCardPath` handler (newebpay-payment.ts:274-302), so the second arrival hits the same code path.

**Commit 2 — guard `NewebPayBindCardRequest.bound()` against double-emit.** Once NotifyURL is wired up, NewebPay will (by design) deliver the result on both ReturnURL and NotifyURL — that's the whole point. But `bound()` had no state guard, so the second arrival would re-run side effects (overwrite `cardId` / `bindingDate` / `expireDate`) and re-emit `CARD_BOUND`, causing downstream consumers to charge twice, insert duplicate periods, send duplicate confirmation emails, etc. The regular order path already filters via state in `handlePaymentResult()`; this aligns the bind-card path with that.

This was a latent gap that became load-bearing once NotifyURL was wired up — splitting it out into a separate commit so the diff is easy to follow.

## Tests

- New spec: decrypts the generated `form.TradeInfo` and asserts both `ReturnURL` and `NotifyURL` resolve to `${serverHost}${boundCardPath}`.
- New spec: calls `bound()` twice on the same request with a deliberately-different second payload, asserts the second call is a no-op (cardId stays first, CARD_BOUND emits exactly once).
- All existing `payments-adapter-newebpay` tests pass.
- `nx lint` and `nx build` clean.

## Notes

Backwards-compatible. The payload field is one NewebPay already documents for bind-card requests; the idempotency guard makes a `bound()` retry a silent no-op, which is what well-behaved consumers already had to assume (some likely just never noticed because no retry path existed).