### PR TITLE
fix(payments-adapter-newebpay): set explicit User-Agent on NewebPay API posts

### DIFF
--- a/packages/payments-adapter-newebpay/__tests__/request-user-agent.spec.ts
+++ b/packages/payments-adapter-newebpay/__tests__/request-user-agent.spec.ts
@@ -1,0 +1,37 @@
+/**
+ * @jest-environment node
+ */
+
+import { NewebPayPayment } from '../src';
+import axios from 'axios';
+
+const MERCHANT_ID = 'MS154366906';
+const AES_KEY = 'X4vM1RymaxkyzZ9mZHNE67Kba2gpv40c';
+const AES_IV = '6ma4zu0UFWk54oyX';
+
+describe('NewebPay API request User-Agent', () => {
+  const payment = new NewebPayPayment({
+    merchantId: MERCHANT_ID,
+    aesKey: AES_KEY,
+    aesIv: AES_IV,
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  // NewebPay's edge (Akamai) returns 403 Access Denied for axios's default
+  // `axios/<version>` User-Agent. Every API POST must send an explicit UA.
+  it('sends an explicit User-Agent on QueryTradeInfo', async () => {
+    const mockedPost = jest.spyOn(axios, 'post').mockResolvedValue({ data: { Status: 'X', Result: {} } } as never);
+
+    // query() triggers the API POST; ignore the downstream CheckCode
+    // validation throw — we only assert the request carried the UA header.
+    await payment.query('order-1', 100).catch(() => undefined);
+
+    expect(mockedPost).toHaveBeenCalled();
+    expect(mockedPost.mock.calls[0]?.[2]).toMatchObject({
+      headers: { 'User-Agent': 'rytass-payments-adapter-newebpay' },
+    });
+  });
+});

--- a/packages/payments-adapter-newebpay/src/newebpay-payment.ts
+++ b/packages/payments-adapter-newebpay/src/newebpay-payment.ts
@@ -60,6 +60,14 @@ import { NewebPayBindCardRequest } from './newebpay-bind-card-request';
 
 const debugPayment = debug('Rytass:Payment:NewebPay');
 
+// NewebPay's edge (Akamai) returns 403 Access Denied for requests carrying
+// axios's default `axios/<version>` User-Agent, which breaks all server-side
+// API calls (QueryTradeInfo / CreditCard Cancel / CreditCard Close). Send an
+// explicit User-Agent so the requests are not blocked.
+const NEWEBPAY_REQUEST_CONFIG = {
+  headers: { 'User-Agent': 'rytass-payments-adapter-newebpay' },
+};
+
 export class NewebPayPayment<CM extends NewebPayCommitMessage = NewebPayCommitMessage>
   implements PaymentGateway<CM, NewebPayOrder<CM>>, BindCardPaymentGateway<CM>
 {
@@ -627,6 +635,7 @@ export class NewebPayPayment<CM extends NewebPayCommitMessage = NewebPayCommitMe
     const { data } = await axios.post<NewebPayAPIResponseWrapper<NewebPayQueryResponsePayload>>(
       `${this.baseUrl}/API/QueryTradeInfo`,
       new URLSearchParams(payload).toString(),
+      NEWEBPAY_REQUEST_CONFIG,
     );
 
     const checkCode = createHash('sha256')
@@ -788,6 +797,7 @@ export class NewebPayPayment<CM extends NewebPayCommitMessage = NewebPayCommitMe
     const { data } = await axios.post<NewebPayAPIResponseWrapper<NewebPayCreditCardCancelResponse>>(
       `${this.baseUrl}/API/CreditCard/Cancel`,
       new URLSearchParams(payload).toString(),
+      NEWEBPAY_REQUEST_CONFIG,
     );
 
     if (data.Status !== 'SUCCESS') {
@@ -840,6 +850,7 @@ export class NewebPayPayment<CM extends NewebPayCommitMessage = NewebPayCommitMe
     const { data } = await axios.post<NewebPayAPIResponseWrapper<NewebPayCreditCardCloseResponse>>(
       `${this.baseUrl}/API/CreditCard/Close`,
       new URLSearchParams(payload).toString(),
+      NEWEBPAY_REQUEST_CONFIG,
     );
 
     if (data.Status !== 'SUCCESS') {
@@ -884,6 +895,7 @@ export class NewebPayPayment<CM extends NewebPayCommitMessage = NewebPayCommitMe
     const { data } = await axios.post<NewebPayAPIResponseWrapper<NewebPayCreditCardCloseResponse>>(
       `${this.baseUrl}/API/CreditCard/Close`,
       new URLSearchParams(payload).toString(),
+      NEWEBPAY_REQUEST_CONFIG,
     );
 
     if (data.Status !== 'SUCCESS') {
@@ -971,6 +983,7 @@ export class NewebPayPayment<CM extends NewebPayCommitMessage = NewebPayCommitMe
     const { data } = await axios.post<NewebPayAPIResponseWrapper<NewebPayCreditCardCloseResponse>>(
       `${this.baseUrl}/API/CreditCard/Close`,
       new URLSearchParams(payload).toString(),
+      NEWEBPAY_REQUEST_CONFIG,
     );
 
     if (data.Status !== 'SUCCESS') {
@@ -1054,6 +1067,7 @@ export class NewebPayPayment<CM extends NewebPayCommitMessage = NewebPayCommitMe
     const { data } = await axios.post<NewebPayAPIResponseWrapper<NewebPayCreditCardCloseResponse>>(
       `${this.baseUrl}/API/CreditCard/Close`,
       new URLSearchParams(payload).toString(),
+      NEWEBPAY_REQUEST_CONFIG,
     );
 
     if (data.Status !== 'SUCCESS') {


### PR DESCRIPTION
## Problem

All server-side NewebPay API calls — `query()` (QueryTradeInfo), `cancel()` and `close()` (CreditCard Cancel/Close) — fail with **HTTP 403 Access Denied** when made from a server.

The 403 comes from NewebPay's edge (Akamai), not the application layer. Root cause: every `axios.post` is sent **without an explicit `User-Agent`**, so axios's default `axios/<version>` UA is used.

This is **not** NewebPay targeting axios specifically. It's a generic **Akamai Bot Manager UA denylist** of well-known automation/scraper clients. Verified by varying only the UA (same endpoint, body, IP, credentials) against NewebPay production `QueryTradeInfo`:

| User-Agent | Result |
|---|---|
| `axios/1.7.9` (axios default) | **403 Access Denied** |
| `curl/8.4.0` | **403 Access Denied** |
| `python-requests/2.31.0` | **403 Access Denied** |
| `node` | 200 SUCCESS |
| `rytass-payments-adapter-newebpay` (this PR) | 200 SUCCESS |
| `Mozilla/5.0` | 200 SUCCESS |
| _(no UA header)_ | 200 SUCCESS |

So any UA not on the denylist passes — including no UA at all. axios just happens to default to `axios/<version>`, which is on the list, so all 6 `axios.post` calls are blocked.

The browser-submitted MPG checkout form is unaffected (browser sends its own UA), and inbound IPN callbacks are unaffected (different direction). This only surfaces on **outbound** server-to-server API calls — e.g. trade reconciliation, refunds, settle.

## Fix

Send an explicit, named `User-Agent` header on every API POST via a shared `NEWEBPAY_REQUEST_CONFIG`. This is standard HTTP-client hygiene (curl/python SDKs set their own UA too), not a workaround targeting a specific rule. Kept `axios.post` (not an axios instance) so existing `jest.spyOn(axios, 'post')` tests still intercept.

## Tests

- Added `__tests__/request-user-agent.spec.ts` asserting the UA header is attached to the request.
- All 117 tests pass; lint + build clean.
