### PR TITLE
feat(storages-adapter-vercel-blob): support private blobs

### DIFF
--- a/packages/storages-adapter-vercel-blob/README.md
+++ b/packages/storages-adapter-vercel-blob/README.md
@@ -45,10 +45,41 @@ await storage.remove(key);
 const results = await storage.batchWrite([buffer1, buffer2]);
 ```
 
+## Private Blobs
+
+Set `access: 'private'` to store blobs that are not publicly accessible. Private
+blobs require authentication, so the adapter behaves differently for reads and URLs:
+
+- `url(key)` returns a short-lived **presigned URL** (signed via `issueSignedToken` +
+  `presignUrl`) instead of a permanent public URL. The presigned URL is cached and
+  only re-issued once it nears expiry, so repeated calls avoid redundant API requests.
+- `read(key)` fetches the blob through that presigned URL transparently.
+- `isExists(key)` / `remove(key)` resolve the blob by its pathname using the token.
+
+```typescript
+import { StorageVercelBlobService } from '@rytass/storages-adapter-vercel-blob';
+
+const storage = new StorageVercelBlobService({
+  token: 'your-blob-read-write-token',
+  pathPrefix: 'private-uploads',
+  access: 'private',
+  signedUrlExpiresIn: 3600, // optional, presigned URL lifetime in seconds (default: 3600)
+});
+
+const { key } = await storage.write(buffer, { filename: 'secret.pdf' });
+
+// Returns a presigned URL valid for `signedUrlExpiresIn` seconds
+const signedUrl = await storage.url(key);
+
+// Reads the private blob through the presigned URL
+const content = await storage.read(key, { format: 'buffer' });
+```
+
 ## Options
 
-| Option       | Type       | Default                          | Description                     |
-|--------------|------------|----------------------------------|---------------------------------|
-| `token`      | `string`   | `process.env.BLOB_READ_WRITE_TOKEN` | Vercel Blob read-write token |
-| `pathPrefix` | `string`   | `'uploads'`                      | Path prefix for stored files    |
-| `access`     | `'public'` | `'public'`                       | Blob access level               |
+| Option               | Type                     | Default                             | Description                                                          |
+|----------------------|--------------------------|-------------------------------------|----------------------------------------------------------------------|
+| `token`              | `string`                 | `process.env.BLOB_READ_WRITE_TOKEN` | Vercel Blob read-write token                                         |
+| `pathPrefix`         | `string`                 | `'uploads'`                         | Path prefix for stored files                                         |
+| `access`             | `'public' \| 'private'`  | `'public'`                          | Blob access level                                                    |
+| `signedUrlExpiresIn` | `number`                 | `3600`                              | Presigned URL lifetime in seconds (private blobs only)               |

--- a/packages/storages-adapter-vercel-blob/__tests__/storages-adapter-vercel-blob.spec.ts
+++ b/packages/storages-adapter-vercel-blob/__tests__/storages-adapter-vercel-blob.spec.ts
@@ -58,8 +58,8 @@ const mockDel = jest.fn().mockImplementation((urlOrPathname: string): Promise<vo
 const mockHead = jest
   .fn()
   .mockImplementation((urlOrPathname: string): Promise<{ size: number; contentType: string }> => {
-    for (const value of fakeStorage.values()) {
-      if (value.url === urlOrPathname) {
+    for (const [key, value] of fakeStorage.entries()) {
+      if (value.url === urlOrPathname || key === urlOrPathname) {
         return Promise.resolve({
           size: value.buffer.length,
           contentType: value.contentType ?? 'application/octet-stream',
@@ -82,11 +82,32 @@ const mockList = jest
     return Promise.resolve({ blobs });
   });
 
+const mockIssueSignedToken = jest.fn().mockImplementation(
+  (options: {
+    pathname: string;
+    validUntil: number;
+  }): Promise<{ delegationToken: string; clientSigningToken: string; validUntil: number }> =>
+    Promise.resolve({
+      delegationToken: `delegation-${options.pathname}`,
+      clientSigningToken: `signing-${options.pathname}`,
+      validUntil: options.validUntil,
+    }),
+);
+
+const mockPresignUrl = jest.fn().mockImplementation(
+  (_signedToken: unknown, options: { pathname: string }): Promise<{ presignedUrl: string }> =>
+    Promise.resolve({
+      presignedUrl: `${FAKE_BLOB_BASE}/${options.pathname}?signed=true`,
+    }),
+);
+
 jest.mock('@vercel/blob', () => ({
   put: mockPut,
   del: mockDel,
   head: mockHead,
   list: mockList,
+  issueSignedToken: mockIssueSignedToken,
+  presignUrl: mockPresignUrl,
 }));
 
 describe('Vercel Blob storage adapter', () => {
@@ -96,6 +117,8 @@ describe('Vercel Blob storage adapter', () => {
     mockDel.mockClear();
     mockHead.mockClear();
     mockList.mockClear();
+    mockIssueSignedToken.mockClear();
+    mockPresignUrl.mockClear();
 
     // Pre-load a saved file
     const savedPathname = `${PATH_PREFIX}/saved-file.png`;
@@ -399,11 +422,9 @@ describe('Vercel Blob storage adapter', () => {
       pathPrefix: PATH_PREFIX,
     });
 
-    const expectedUrl = `${FAKE_BLOB_BASE}/${PATH_PREFIX}/saved-file.png`;
-
     await service.remove('saved-file.png');
 
-    expect(mockDel).toHaveBeenCalledWith(expectedUrl, { token: TOKEN });
+    expect(mockDel).toHaveBeenCalledWith(`${PATH_PREFIX}/saved-file.png`, { token: TOKEN });
 
     // Cache should be cleared — next url() call should query list() again
     await expect(service.url('saved-file.png')).rejects.toThrow();
@@ -490,5 +511,205 @@ describe('Vercel Blob storage adapter', () => {
     await service.write(sampleFileBuffer);
 
     expect(mockPut).not.toHaveBeenCalled(); // File exists with default prefix, so dedup skips upload
+  });
+});
+
+describe('Vercel Blob storage adapter (private access)', () => {
+  beforeEach(() => {
+    fakeStorage.clear();
+    mockPut.mockClear();
+    mockDel.mockClear();
+    mockHead.mockClear();
+    mockList.mockClear();
+    mockIssueSignedToken.mockClear();
+    mockPresignUrl.mockClear();
+
+    const savedPathname = `${PATH_PREFIX}/saved-file.png`;
+
+    fakeStorage.set(savedPathname, {
+      buffer: sampleFileBuffer,
+      url: `${FAKE_BLOB_BASE}/${savedPathname}`,
+      pathname: savedPathname,
+      contentType: 'image/png',
+    });
+  });
+
+  it('should upload with private access', async () => {
+    const { StorageVercelBlobService } = await import('../src');
+
+    const service = new StorageVercelBlobService({
+      token: TOKEN,
+      pathPrefix: PATH_PREFIX,
+      access: 'private',
+    });
+
+    await service.write(sampleFileBuffer, { filename: 'private-file.png' });
+
+    expect(mockPut).toHaveBeenCalledWith(
+      `${PATH_PREFIX}/private-file.png`,
+      sampleFileBuffer,
+      expect.objectContaining({
+        access: 'private',
+        token: TOKEN,
+        addRandomSuffix: false,
+      }),
+    );
+  });
+
+  it('should return a presigned url for private blobs', async () => {
+    const { StorageVercelBlobService } = await import('../src');
+
+    const service = new StorageVercelBlobService({
+      token: TOKEN,
+      pathPrefix: PATH_PREFIX,
+      access: 'private',
+    });
+
+    const url = await service.url('saved-file.png');
+
+    expect(url).toBe(`${FAKE_BLOB_BASE}/${PATH_PREFIX}/saved-file.png?signed=true`);
+    expect(mockList).not.toHaveBeenCalled();
+    expect(mockIssueSignedToken).toHaveBeenCalledWith(
+      expect.objectContaining({
+        token: TOKEN,
+        pathname: `${PATH_PREFIX}/saved-file.png`,
+        operations: ['get'],
+      }),
+    );
+
+    expect(mockPresignUrl).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        access: 'private',
+        operation: 'get',
+        pathname: `${PATH_PREFIX}/saved-file.png`,
+      }),
+    );
+  });
+
+  it('should reuse a cached presigned url before it nears expiry', async () => {
+    const { StorageVercelBlobService } = await import('../src');
+
+    const service = new StorageVercelBlobService({
+      token: TOKEN,
+      pathPrefix: PATH_PREFIX,
+      access: 'private',
+    });
+
+    await service.url('saved-file.png');
+    await service.url('saved-file.png');
+
+    expect(mockIssueSignedToken).toHaveBeenCalledTimes(1);
+    expect(mockPresignUrl).toHaveBeenCalledTimes(1);
+  });
+
+  it('should re-issue a presigned url once it is close to expiry', async () => {
+    const { StorageVercelBlobService } = await import('../src');
+
+    // 10s lifetime → 1s refresh threshold (10%). Advancing the clock past 90%
+    // of the lifetime should drop the cached url below the threshold and trigger
+    // a re-issue on the next url() call.
+    const service = new StorageVercelBlobService({
+      token: TOKEN,
+      pathPrefix: PATH_PREFIX,
+      access: 'private',
+      signedUrlExpiresIn: 10,
+    });
+
+    jest.useFakeTimers();
+
+    try {
+      await service.url('saved-file.png');
+
+      expect(mockIssueSignedToken).toHaveBeenCalledTimes(1);
+
+      jest.advanceTimersByTime(9_500); // 0.5s remaining < 1s threshold
+
+      await service.url('saved-file.png');
+
+      expect(mockIssueSignedToken).toHaveBeenCalledTimes(2);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('should respect a custom signed url lifetime', async () => {
+    const { StorageVercelBlobService } = await import('../src');
+
+    const service = new StorageVercelBlobService({
+      token: TOKEN,
+      pathPrefix: PATH_PREFIX,
+      access: 'private',
+      signedUrlExpiresIn: 900,
+    });
+
+    const before = Date.now();
+
+    await service.url('saved-file.png');
+
+    const { validUntil } = mockIssueSignedToken.mock.calls[0][0] as { validUntil: number };
+
+    expect(validUntil).toBeGreaterThanOrEqual(before + 900 * 1000);
+    expect(validUntil).toBeLessThanOrEqual(Date.now() + 900 * 1000);
+  });
+
+  it('should read a private blob through its presigned url', async () => {
+    const { StorageVercelBlobService } = await import('../src');
+
+    const service = new StorageVercelBlobService({
+      token: TOKEN,
+      pathPrefix: PATH_PREFIX,
+      access: 'private',
+    });
+
+    const fetchSpy = jest.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(sampleFileBuffer, { status: 200 }));
+
+    const buffer = await service.read('saved-file.png', { format: 'buffer' });
+
+    expect(Buffer.isBuffer(buffer)).toBe(true);
+    expect(Buffer.compare(buffer, sampleFileBuffer)).toBe(0);
+    expect(fetchSpy).toHaveBeenCalledWith(`${FAKE_BLOB_BASE}/${PATH_PREFIX}/saved-file.png?signed=true`);
+
+    fetchSpy.mockRestore();
+  });
+
+  it('should check existence via pathname for private blobs', async () => {
+    const { StorageVercelBlobService } = await import('../src');
+
+    const service = new StorageVercelBlobService({
+      token: TOKEN,
+      pathPrefix: PATH_PREFIX,
+      access: 'private',
+    });
+
+    const exists = await service.isExists('saved-file.png');
+    const notExists = await service.isExists('nonexistent-file');
+
+    expect(exists).toBe(true);
+    expect(notExists).toBe(false);
+    expect(mockHead).toHaveBeenCalledWith(`${PATH_PREFIX}/saved-file.png`, { token: TOKEN });
+  });
+
+  it('should clear the presigned url cache on remove', async () => {
+    const { StorageVercelBlobService } = await import('../src');
+
+    const service = new StorageVercelBlobService({
+      token: TOKEN,
+      pathPrefix: PATH_PREFIX,
+      access: 'private',
+    });
+
+    await service.url('saved-file.png');
+
+    expect(mockIssueSignedToken).toHaveBeenCalledTimes(1);
+
+    await service.remove('saved-file.png');
+
+    expect(mockDel).toHaveBeenCalledWith(`${PATH_PREFIX}/saved-file.png`, { token: TOKEN });
+
+    // Re-issuing after removal proves the cache entry was dropped.
+    await service.url('saved-file.png');
+
+    expect(mockIssueSignedToken).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/storages-adapter-vercel-blob/package.json
+++ b/packages/storages-adapter-vercel-blob/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rytass/storages-adapter-vercel-blob",
-  "version": "0.0.3",
+  "version": "0.1.0",
   "description": "Vercel Blob storage adapter",
   "keywords": [
     "rytass",
@@ -27,6 +27,6 @@
   },
   "dependencies": {
     "@rytass/storages": "^0.2.7",
-    "@vercel/blob": "^0.27.1"
+    "@vercel/blob": "^2.4.0"
   }
 }

--- a/packages/storages-adapter-vercel-blob/src/storages-adapter-vercel-blob.ts
+++ b/packages/storages-adapter-vercel-blob/src/storages-adapter-vercel-blob.ts
@@ -8,18 +8,35 @@ import {
   StorageFile,
   WriteFileOptions,
 } from '@rytass/storages';
-import { put, del, head, list } from '@vercel/blob';
+import { BlobAccessType, put, del, head, list, issueSignedToken, presignUrl } from '@vercel/blob';
 import { Readable, PassThrough } from 'stream';
 import { StorageVercelBlobOptions } from './typings';
+
+const DEFAULT_SIGNED_URL_EXPIRES_IN = 3600;
+
+// Re-issue a presigned URL once its remaining lifetime drops below this fraction
+// of the configured lifetime, so callers never receive an almost-expired URL.
+const SIGNED_URL_REFRESH_THRESHOLD = 0.1;
+
+interface CachedSignedUrl {
+  url: string;
+  expiresAt: number;
+}
 
 export class StorageVercelBlobService extends Storage<StorageVercelBlobOptions> {
   private readonly token: string;
 
   private readonly pathPrefix: string;
 
-  private readonly access: 'public';
+  private readonly access: BlobAccessType;
 
+  private readonly signedUrlExpiresIn: number;
+
+  // Permanent public URLs — safe to cache for the lifetime of the service.
   private readonly keyUrlCache = new Map<string, string>();
+
+  // Presigned private URLs — expire, so cached together with their expiry timestamp.
+  private readonly signedUrlCache = new Map<string, CachedSignedUrl>();
 
   constructor(options: StorageVercelBlobOptions) {
     super(options);
@@ -36,9 +53,22 @@ export class StorageVercelBlobService extends Storage<StorageVercelBlobOptions> 
     this.token = token;
     this.pathPrefix = options.pathPrefix ?? 'uploads';
     this.access = options.access ?? 'public';
+    this.signedUrlExpiresIn = options.signedUrlExpiresIn ?? DEFAULT_SIGNED_URL_EXPIRES_IN;
+  }
+
+  private pathnameOf(key: string): string {
+    return `${this.pathPrefix}/${key}`;
   }
 
   async url(key: string): Promise<string> {
+    if (this.access === 'private') {
+      return this.privateUrl(key);
+    }
+
+    return this.publicUrl(key);
+  }
+
+  private async publicUrl(key: string): Promise<string> {
     const cached = this.keyUrlCache.get(key);
 
     if (cached) {
@@ -60,6 +90,41 @@ export class StorageVercelBlobService extends Storage<StorageVercelBlobOptions> 
     this.keyUrlCache.set(key, blob.url);
 
     return blob.url;
+  }
+
+  private async issuePresignedUrl(key: string): Promise<CachedSignedUrl> {
+    const pathname = this.pathnameOf(key);
+    const validUntil = Date.now() + this.signedUrlExpiresIn * 1000;
+
+    const signedToken = await issueSignedToken({
+      token: this.token,
+      pathname,
+      operations: ['get'],
+      validUntil,
+    });
+
+    const { presignedUrl } = await presignUrl(signedToken, {
+      access: 'private',
+      operation: 'get',
+      pathname,
+    });
+
+    return { url: presignedUrl, expiresAt: signedToken.validUntil };
+  }
+
+  private async privateUrl(key: string): Promise<string> {
+    const cached = this.signedUrlCache.get(key);
+    const refreshBefore = this.signedUrlExpiresIn * 1000 * SIGNED_URL_REFRESH_THRESHOLD;
+
+    if (cached && cached.expiresAt - Date.now() > refreshBefore) {
+      return cached.url;
+    }
+
+    const fresh = await this.issuePresignedUrl(key);
+
+    this.signedUrlCache.set(key, fresh);
+
+    return fresh.url;
   }
 
   read(key: string): Promise<Readable>;
@@ -99,7 +164,7 @@ export class StorageVercelBlobService extends Storage<StorageVercelBlobOptions> 
       return { key: filename };
     }
 
-    const pathname = `${this.pathPrefix}/${filename}`;
+    const pathname = this.pathnameOf(filename);
 
     const result = await put(pathname, buffer, {
       access: this.access,
@@ -108,7 +173,7 @@ export class StorageVercelBlobService extends Storage<StorageVercelBlobOptions> 
       addRandomSuffix: false,
     });
 
-    this.keyUrlCache.set(filename, result.url);
+    this.cacheWrittenUrl(filename, result.url);
 
     return { key: filename };
   }
@@ -132,7 +197,7 @@ export class StorageVercelBlobService extends Storage<StorageVercelBlobOptions> 
       }
 
       const buffer = Buffer.concat(chunks);
-      const pathname = `${this.pathPrefix}/${givenFilename}`;
+      const pathname = this.pathnameOf(givenFilename);
 
       const result = await put(pathname, buffer, {
         access: this.access,
@@ -141,7 +206,7 @@ export class StorageVercelBlobService extends Storage<StorageVercelBlobOptions> 
         addRandomSuffix: false,
       });
 
-      this.keyUrlCache.set(givenFilename, result.url);
+      this.cacheWrittenUrl(givenFilename, result.url);
 
       return { key: givenFilename };
     }
@@ -171,7 +236,7 @@ export class StorageVercelBlobService extends Storage<StorageVercelBlobOptions> 
     }
 
     const buffer = Buffer.concat(chunks);
-    const pathname = `${this.pathPrefix}/${filename}`;
+    const pathname = this.pathnameOf(filename);
 
     const result = await put(pathname, buffer, {
       access: this.access,
@@ -180,9 +245,18 @@ export class StorageVercelBlobService extends Storage<StorageVercelBlobOptions> 
       addRandomSuffix: false,
     });
 
-    this.keyUrlCache.set(filename, result.url);
+    this.cacheWrittenUrl(filename, result.url);
 
     return { key: filename };
+  }
+
+  // The URL returned by `put` is only directly usable for public blobs. Private
+  // blobs must be served through a freshly presigned URL, so we never cache the
+  // raw private URL.
+  private cacheWrittenUrl(key: string, url: string): void {
+    if (this.access === 'public') {
+      this.keyUrlCache.set(key, url);
+    }
   }
 
   write(file: InputFile, options?: WriteFileOptions): Promise<StorageFile> {
@@ -198,18 +272,15 @@ export class StorageVercelBlobService extends Storage<StorageVercelBlobOptions> 
   }
 
   async remove(key: string): Promise<void> {
-    const fileUrl = await this.url(key);
-
-    await del(fileUrl, { token: this.token });
+    await del(this.pathnameOf(key), { token: this.token });
 
     this.keyUrlCache.delete(key);
+    this.signedUrlCache.delete(key);
   }
 
   async isExists(key: string): Promise<boolean> {
     try {
-      const fileUrl = await this.url(key);
-
-      await head(fileUrl, { token: this.token });
+      await head(this.pathnameOf(key), { token: this.token });
 
       return true;
     } catch {

--- a/packages/storages-adapter-vercel-blob/src/typings.ts
+++ b/packages/storages-adapter-vercel-blob/src/typings.ts
@@ -1,8 +1,21 @@
 import { StorageOptions } from '@rytass/storages';
+import { BlobAccessType } from '@vercel/blob';
 
 export interface StorageVercelBlobOptions extends StorageOptions {
   token?: string;
   pathPrefix?: string;
-  access?: 'public';
+  /**
+   * Blob access level.
+   * - `public`: blobs are served from a permanent, anonymous URL.
+   * - `private`: blobs require authentication; `url()` returns a short-lived presigned URL.
+   * @default 'public'
+   */
+  access?: BlobAccessType;
+  /**
+   * For private blobs only: lifetime (in seconds) of the presigned URL returned by `url()`.
+   * Ignored for public blobs (their URLs are permanent).
+   * @default 3600
+   */
+  signedUrlExpiresIn?: number;
   [key: string]: unknown;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4622,13 +4622,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@fastify/busboy@npm:^2.0.0":
-  version: 2.1.1
-  resolution: "@fastify/busboy@npm:2.1.1"
-  checksum: 10c0/6f8027a8cba7f8f7b736718b013f5a38c0476eea67034c94a0d3c375e2b114366ad4419e6a6fa7ffc2ef9c6d3e0435d76dd584a7a1cbac23962fda7650b579e3
-  languageName: node
-  linkType: hard
-
 "@fastify/deepmerge@npm:^2.0.0":
   version: 2.0.2
   resolution: "@fastify/deepmerge@npm:2.0.2"
@@ -8454,7 +8447,7 @@ __metadata:
   resolution: "@rytass/storages-adapter-vercel-blob@workspace:packages/storages-adapter-vercel-blob"
   dependencies:
     "@rytass/storages": "npm:^0.2.7"
-    "@vercel/blob": "npm:^0.27.1"
+    "@vercel/blob": "npm:^2.4.0"
   languageName: unknown
   linkType: soft
 
@@ -10981,16 +10974,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vercel/blob@npm:^0.27.1":
-  version: 0.27.3
-  resolution: "@vercel/blob@npm:0.27.3"
+"@vercel/blob@npm:^2.4.0":
+  version: 2.4.0
+  resolution: "@vercel/blob@npm:2.4.0"
   dependencies:
     async-retry: "npm:^1.3.3"
     is-buffer: "npm:^2.0.5"
     is-node-process: "npm:^1.2.0"
     throttleit: "npm:^2.1.0"
-    undici: "npm:^5.28.4"
-  checksum: 10c0/2bacd3fa67e6386c9fcf4b61dbaee08a5439bfd1bafcbbf17b1b4a1556b39c974ee7f7453a27ede5d32e8b645dfac4eaba831173da3331f118daf8ac579c3993
+    undici: "npm:^6.23.0"
+  checksum: 10c0/cc8c6dc6203ec2bb09094e64d5751246e16413fd8607f512a6e8b6f03b5a2286f4e87f4809ba340027e7b7eadc030580f16b70a6342c90164ae09c4abcfd5471
   languageName: node
   linkType: hard
 
@@ -29239,12 +29232,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"undici@npm:^5.28.4":
-  version: 5.29.0
-  resolution: "undici@npm:5.29.0"
-  dependencies:
-    "@fastify/busboy": "npm:^2.0.0"
-  checksum: 10c0/e4e4d631ca54ee0ad82d2e90e7798fa00a106e27e6c880687e445cc2f13b4bc87c5eba2a88c266c3eecffb18f26e227b778412da74a23acc374fca7caccec49b
+"undici@npm:^6.23.0":
+  version: 6.26.0
+  resolution: "undici@npm:6.26.0"
+  checksum: 10c0/cf2b4caf58c33d6582970991290cc7a6486d6e738845f25dcdd16952d708ec844815c6d30362919764fcaf30f719891289341f1ada496f003ce2700310453a47
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Adds private blob support to `@rytass/storages-adapter-vercel-blob` (bumped to `v0.1.0`).

Upgrades `@vercel/blob` `^0.27.1` → `^2.4.0` and introduces `access: 'private'`.

## Changes

- **`url(key)`** — for private blobs, returns a short-lived **presigned URL** (`issueSignedToken` + `presignUrl`), cached and re-issued only when nearing expiry (re-sign once remaining lifetime drops below 10%). Public blobs keep their permanent `list`-based URL behaviour.
- **`read(key)`** — transparently fetches private blobs through the presigned URL; no caller change.
- **`isExists()` / `remove()`** — resolve blobs by pathname via the token (v2.4.0), covering both public and private access.
- **New option** `signedUrlExpiresIn` (default `3600`s) controls presigned URL lifetime.

## Tests

29 tests pass (8 new private-blob cases): upload with private access, presigned URL issuance + caching, re-issue near expiry (fake timers), custom lifetime, private read, pathname-based exists, cache invalidation on remove.

Build (typecheck) and lint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)