### PR TITLE
fix(invoice-adapter-bank-pro): skip ER016 error on invoice issue

### DIFF
--- a/packages/invoice-adapter-bank-pro/__tests__/bank-pro-gateway-api.spec.ts
+++ b/packages/invoice-adapter-bank-pro/__tests__/bank-pro-gateway-api.spec.ts
@@ -82,6 +82,61 @@ describe('BankProInvoiceGateway API Tests', () => {
       await expect(gateway.issue(mockIssueOptions)).rejects.toThrow('Some error occurred');
     });
 
+    it('should treat ER016 error as non-fatal and still return the issued invoice', async () => {
+      mockedAxios.post.mockResolvedValueOnce({
+        data: [
+          {
+            InvoiceNo: 'AB12345678',
+            RandomNumber: '1234',
+            InvoiceDate: '2025/01/10 10:00:00',
+            ErrorMessage: 'ER016會員地址欄位不可空白！',
+          },
+        ],
+      });
+
+      const invoice = await gateway.issue(mockIssueOptions);
+
+      expect(invoice.invoiceNumber).toBe('AB12345678');
+      expect(invoice.randomCode).toBe('1234');
+    });
+
+    it('should match non-fatal error by ER016 code prefix regardless of trailing message', async () => {
+      mockedAxios.post.mockResolvedValueOnce({
+        data: [
+          {
+            InvoiceNo: 'AB12345678',
+            RandomNumber: '1234',
+            InvoiceDate: '2025/01/10 10:00:00',
+            ErrorMessage: 'ER016 address field is empty',
+          },
+        ],
+      });
+
+      const invoice = await gateway.issue(mockIssueOptions);
+
+      expect(invoice.invoiceNumber).toBe('AB12345678');
+    });
+
+    it('should still throw when a fatal error coexists with ER016, excluding ER016 from the message', async () => {
+      mockedAxios.post.mockResolvedValueOnce({
+        data: [
+          {
+            InvoiceNo: 'AB12345678',
+            RandomNumber: '1234',
+            InvoiceDate: '2025/01/10 10:00:00',
+            ErrorMessage: 'ER016會員地址欄位不可空白！',
+          },
+          {
+            ErrorMessage: 'Some fatal error',
+          },
+        ],
+      });
+
+      await expect(gateway.issue(mockIssueOptions)).rejects.toThrow(
+        expect.objectContaining({ message: 'Some fatal error' }),
+      );
+    });
+
     it('should handle mobile carrier type', async () => {
       mockedAxios.post.mockResolvedValueOnce({
         data: [

--- a/packages/invoice-adapter-bank-pro/src/bank-pro-invoice-gateway.ts
+++ b/packages/invoice-adapter-bank-pro/src/bank-pro-invoice-gateway.ts
@@ -228,7 +228,8 @@ export class BankProInvoiceGateway implements InvoiceGateway<
       throw new Error('Failed to issue invoice');
     }
 
-    if (data.some(response => response.ErrorMessage)) {
+    // 「ER016會員地址欄位不可空白！」still returns valid invoice data on production — treat it as a non-fatal warning
+    if (data.some(response => response.ErrorMessage && response.ErrorMessage !== 'ER016會員地址欄位不可空白！')) {
       throw new Error(data.map(response => response.ErrorMessage).join(', '));
     }
 

--- a/packages/invoice-adapter-bank-pro/src/bank-pro-invoice-gateway.ts
+++ b/packages/invoice-adapter-bank-pro/src/bank-pro-invoice-gateway.ts
@@ -34,6 +34,12 @@ import {
   BankProVoidInvoiceResponse,
 } from './typings';
 
+// 開立發票時，部分錯誤碼（如 ER016「會員地址欄位不可空白！」）在正式環境仍會回傳有效的發票資料，視為非致命警告
+const NON_FATAL_ISSUE_ERROR_CODES: readonly string[] = ['ER016'];
+
+const isNonFatalIssueError = (errorMessage: string): boolean =>
+  NON_FATAL_ISSUE_ERROR_CODES.some(code => errorMessage.startsWith(code));
+
 export class BankProInvoiceGateway implements InvoiceGateway<
   BankProPaymentItem,
   BankProInvoice,
@@ -228,9 +234,12 @@ export class BankProInvoiceGateway implements InvoiceGateway<
       throw new Error('Failed to issue invoice');
     }
 
-    // 「ER016會員地址欄位不可空白！」still returns valid invoice data on production — treat it as a non-fatal warning
-    if (data.some(response => response.ErrorMessage && response.ErrorMessage !== 'ER016會員地址欄位不可空白！')) {
-      throw new Error(data.map(response => response.ErrorMessage).join(', '));
+    const fatalErrorMessages = data
+      .map(response => response.ErrorMessage)
+      .filter(errorMessage => errorMessage && !isNonFatalIssueError(errorMessage));
+
+    if (fatalErrorMessages.length > 0) {
+      throw new Error(fatalErrorMessages.join(', '));
     }
 
     return new BankProInvoice({


### PR DESCRIPTION
- ER016「會員地址欄位不可空白！」is returned on production even when
  the invoice is successfully issued; treat it as a non-fatal warning
- Only throw when a different, non-empty ErrorMessage is present