### PR TITLE
fix(payments-adapter-ecpay): use encodeURIComponent for ticket MAC

### DIFF
--- a/packages/payments-adapter-ecpay/src/ecpay-utils.ts
+++ b/packages/payments-adapter-ecpay/src/ecpay-utils.ts
@@ -13,5 +13,5 @@ export function ecpaySha256(raw: string): string {
 // 無欄位名前綴、無 &。注意：此公式僅適用於票證 API，與一般 AIO 金流的參數排序式 MAC 不同。
 // 參考：https://developers.ecpay.com.tw/?p=29998
 export function computeTicketCheckMacValue(plaintext: string, creds: { hashKey: string; hashIv: string }): string {
-  return ecpaySha256(ecpayUrlEncode(`${creds.hashKey}${plaintext}${creds.hashIv}`));
+  return ecpaySha256(encodeURIComponent(`${creds.hashKey}${plaintext}${creds.hashIv}`).toLowerCase());
 }


### PR DESCRIPTION
The ticket API CheckMacValue requires standard percent-encoding (encodeURIComponent) lowercased, not the custom ecpayUrlEncode used by AIO payment flows. Using the wrong encoder produced invalid MACs for ticket API requests.