### PR TITLE
feat(payments-adapter-ctbc-micro-fast-pay): detect HTML error pages

### DIFF
--- a/packages/payments-adapter-ctbc-micro-fast-pay/README.md
+++ b/packages/payments-adapter-ctbc-micro-fast-pay/README.md
@@ -950,6 +950,77 @@ export default CTBCPayment;
 
 ## Error Handling
 
+### Typed Errors
+
+The package exports typed error classes so callers can branch on the failure cause instead of matching error messages:
+
+| Error class                  | Thrown when                                                                    | Extra properties                 |
+| ---------------------------- | ------------------------------------------------------------------------------ | -------------------------------- |
+| `CTBCHtmlErrorResponseError` | CTBC returns an HTML page (maintenance notice, WAF block) instead of a payload | `responseText`                   |
+| `CTBCPosQueryFailedError`    | The POS gateway answers a query with a non-`00` `ErrCode`                      | `respCode`, `errCode`, `errDesc` |
+| `CtbcPaymentFailedError`     | A payment is rejected by the gateway                                           | `orderId`                        |
+
+> **Behaviour change (since 0.1.25):** the `posApi*` helpers previously signalled every failure by
+> returning a numeric error code from `CTBC_ERROR_CODES`. They now **throw**
+> `CTBCHtmlErrorResponseError` when CTBC serves an HTML page — this case used to be masked as
+> `ERR_HOST_CONNECTION_FAILED`, which was indistinguishable from a genuine network failure. All other
+> failures still come back as numeric codes. Code that only checks `typeof result === 'number'` should
+> add a `try`/`catch`.
+
+```typescript
+import {
+  posApiQuery,
+  CTBCHtmlErrorResponseError,
+  CTBCPosQueryFailedError,
+  CTBC_ERROR_CODES,
+} from '@rytass/payments-adapter-ctbc-micro-fast-pay';
+
+try {
+  const result = await posApiQuery(posApiConfig, queryParams);
+
+  if (typeof result === 'number') {
+    // Validation / network / parsing failures still surface as numeric codes
+    console.error('Query failed with error code:', result);
+
+    return;
+  }
+
+  console.log('Current state:', result.CurrentState);
+} catch (error) {
+  if (error instanceof CTBCHtmlErrorResponseError) {
+    // CTBC is under maintenance — safe to retry later, do NOT treat as a payment failure.
+    // `message` carries a truncated preview; `responseText` holds the full page for diagnostics.
+    console.error('CTBC returned an HTML error page:', error.message);
+    await alerting.notify('ctbc-maintenance', error.responseText);
+
+    return;
+  }
+
+  throw error;
+}
+```
+
+`CTBCPayment.query()` wraps the same failure modes: it throws `CTBCPosQueryFailedError` when the POS
+gateway reports a query error, and lets `CTBCHtmlErrorResponseError` propagate untouched.
+
+```typescript
+try {
+  const order = await paymentGateway.query('ORDER_ID');
+} catch (error) {
+  if (error instanceof CTBCHtmlErrorResponseError) {
+    console.error('CTBC under maintenance, retry later');
+  } else if (error instanceof CTBCPosQueryFailedError) {
+    console.error(`Query rejected: ${error.errCode} - ${error.errDesc}`);
+  } else {
+    throw error;
+  }
+}
+```
+
+When a refund or refund cancellation hits an HTML error page, the order is marked `FAILED` with
+`failedCode` set to `CTBC_HTML_ERROR_RESPONSE_FAILED_CODE` (`'HTML_ERROR_RESPONSE'`) before the error
+is re-thrown.
+
 ### Common Error Scenarios
 
 ```typescript

--- a/packages/payments-adapter-ctbc-micro-fast-pay/README.md
+++ b/packages/payments-adapter-ctbc-micro-fast-pay/README.md
@@ -960,7 +960,7 @@ The package exports typed error classes so callers can branch on the failure cau
 | `CTBCPosQueryFailedError`    | The POS gateway answers a query with a non-`00` `ErrCode`                      | `respCode`, `errCode`, `errDesc` |
 | `CtbcPaymentFailedError`     | A payment is rejected by the gateway                                           | `orderId`                        |
 
-> **Behaviour change (since 0.1.25):** the `posApi*` helpers previously signalled every failure by
+> **Behaviour change:** the `posApi*` helpers previously signalled every failure by
 > returning a numeric error code from `CTBC_ERROR_CODES`. They now **throw**
 > `CTBCHtmlErrorResponseError` when CTBC serves an HTML page — this case used to be masked as
 > `ERR_HOST_CONNECTION_FAILED`, which was indistinguishable from a genuine network failure. All other

--- a/packages/payments-adapter-ctbc-micro-fast-pay/__tests__/ctbc-order.spec.ts
+++ b/packages/payments-adapter-ctbc-micro-fast-pay/__tests__/ctbc-order.spec.ts
@@ -7,6 +7,7 @@ import { CardType, OrderState, PaymentEvents } from '@rytass/payments';
 import { CTBCOrder } from '../src/ctbc-order';
 import { CTBCPayment } from '../src/ctbc-payment';
 import { CTBCOrderCommitMessage } from '../src/typings';
+import { CTBC_HTML_ERROR_RESPONSE_FAILED_CODE, CTBCHtmlErrorResponseError } from '../src/errors';
 
 // Mock POS API utils
 jest.mock('../src/ctbc-pos-api-utils', () => ({
@@ -34,6 +35,10 @@ const amexSmartFlowMock = amexApiUtils.amexSmartCancelOrRefund as jest.MockedFun
 >;
 
 const amexCancelRefundMock = amexApiUtils.amexCancelRefund as jest.MockedFunction<typeof amexApiUtils.amexCancelRefund>;
+
+const posApiCancelRefundMock = posApiUtils.posApiCancelRefund as jest.MockedFunction<
+  typeof posApiUtils.posApiCancelRefund
+>;
 
 describe('CTBCOrder unit tests', () => {
   const TEST_MERID = 'TEST_MERID';
@@ -424,6 +429,51 @@ describe('CTBCOrder unit tests', () => {
 
       await expect(order.refund(50)).rejects.toBe('Unknown error type');
       expect(order.state).toBe(OrderState.FAILED);
+    });
+
+    it('should propagate CTBCHtmlErrorResponseError and tag the order with the HTML failure code', async () => {
+      const order = new CTBCOrder({
+        id: 'ORDER024',
+        items: [{ name: 'Item', unitPrice: 100, quantity: 1 }],
+        gateway: payment,
+        committedAt: new Date(),
+        additionalInfo: { xid: 'XID123', authCode: 'AUTH123' },
+      });
+
+      const htmlError = new CTBCHtmlErrorResponseError('<html><body>系統維護中</body></html>');
+
+      posApiSmartFlowMock.mockRejectedValue(htmlError);
+
+      await expect(order.refund(50)).rejects.toBe(htmlError);
+      expect(order.state).toBe(OrderState.FAILED);
+      expect(order.failedMessage).toEqual({
+        code: CTBC_HTML_ERROR_RESPONSE_FAILED_CODE,
+        message: htmlError.message,
+      });
+    });
+  });
+
+  describe('cancelRefund with POS API', () => {
+    it('should propagate CTBCHtmlErrorResponseError and tag the order with the HTML failure code', async () => {
+      const order = new CTBCOrder({
+        id: 'ORDER025',
+        items: [{ name: 'Item', unitPrice: 100, quantity: 1 }],
+        gateway: payment,
+        committedAt: new Date(),
+        refundedAt: new Date(),
+        additionalInfo: { xid: 'XID123', authCode: 'AUTH123' },
+      });
+
+      const htmlError = new CTBCHtmlErrorResponseError('<html><body>系統維護中</body></html>');
+
+      posApiCancelRefundMock.mockRejectedValue(htmlError);
+
+      await expect(order.cancelRefund(50)).rejects.toBe(htmlError);
+      expect(order.state).toBe(OrderState.FAILED);
+      expect(order.failedMessage).toEqual({
+        code: CTBC_HTML_ERROR_RESPONSE_FAILED_CODE,
+        message: htmlError.message,
+      });
     });
   });
 

--- a/packages/payments-adapter-ctbc-micro-fast-pay/__tests__/ctbc-payment.spec.ts
+++ b/packages/payments-adapter-ctbc-micro-fast-pay/__tests__/ctbc-payment.spec.ts
@@ -41,7 +41,7 @@ jest.mock('../src/ctbc-amex-api-utils', () => ({
 
 import { CardType, PaymentEvents } from '@rytass/payments';
 import iconv from 'iconv-lite';
-import { CtbcPaymentFailedError } from '../src/errors';
+import { CtbcPaymentFailedError, CTBCPosQueryFailedError } from '../src/errors';
 import { CTBCBindCardRequest } from '../src/ctbc-bind-card-request';
 import { CTBCPayment } from '../src/ctbc-payment';
 import { CTBCOrder } from '../src/ctbc-order';
@@ -195,6 +195,46 @@ describe('CTBCPayment core behaviours', () => {
 
     mockedPosQuery.mockResolvedValueOnce({ ErrCode: '01', ERRDESC: 'oops', RespCode: '1', CurrentState: '' });
     await expect(payment.query('ERR2')).rejects.toThrow('Query failed, RespCode: 1 - ErrCode: 01 - ErrDesc: oops');
+  });
+
+  it('query throws CTBCPosQueryFailedError with RespCode/ErrCode/ErrDesc on POS gateway error', async () => {
+    const payment = new CTBCPayment(baseOptions);
+
+    mockedPosQuery.mockResolvedValueOnce({ ErrCode: '01', ERRDESC: 'oops', RespCode: '1', CurrentState: '' });
+
+    let caughtError: unknown;
+
+    try {
+      await payment.query('ERR2');
+    } catch (error) {
+      caughtError = error;
+    }
+
+    expect(caughtError).toBeInstanceOf(CTBCPosQueryFailedError);
+    expect((caughtError as CTBCPosQueryFailedError).respCode).toBe('1');
+    expect((caughtError as CTBCPosQueryFailedError).errCode).toBe('01');
+    expect((caughtError as CTBCPosQueryFailedError).errDesc).toBe('oops');
+    expect((caughtError as CTBCPosQueryFailedError).name).toBe('CTBCPosQueryFailedError');
+  });
+
+  it('query defaults errDesc to "Unknown error" when ERRDESC is missing', async () => {
+    const payment = new CTBCPayment(baseOptions);
+
+    mockedPosQuery.mockResolvedValueOnce({ ErrCode: '02', RespCode: '1', CurrentState: '' });
+
+    let caughtError: unknown;
+
+    try {
+      await payment.query('ERR3');
+    } catch (error) {
+      caughtError = error;
+    }
+
+    expect(caughtError).toBeInstanceOf(CTBCPosQueryFailedError);
+    expect((caughtError as CTBCPosQueryFailedError).errDesc).toBe('Unknown error');
+    expect((caughtError as CTBCPosQueryFailedError).message).toBe(
+      'Query failed, RespCode: 1 - ErrCode: 02 - ErrDesc: Unknown error',
+    );
   });
 
   it('query reconstructs order from POS response', async () => {

--- a/packages/payments-adapter-ctbc-micro-fast-pay/__tests__/ctbc-pos-api-utils.spec.ts
+++ b/packages/payments-adapter-ctbc-micro-fast-pay/__tests__/ctbc-pos-api-utils.spec.ts
@@ -9,10 +9,12 @@ import {
   posApiCapRev,
   posApiSmartCancelOrRefund,
   getPosNextActionFromInquiry,
-  CTBCHtmlErrorResponseError,
 } from '../src/ctbc-pos-api-utils';
 import { setSSLAuthIV } from '../src/ctbc-crypto-core';
+import { CTBCHtmlErrorResponseError } from '../src/errors';
 import { CTBC_ERROR_CODES, CTBCPosApiConfig, CTBCPosApiResponse } from '../src/typings';
+import crypto from 'node:crypto';
+import * as iconv from 'iconv-lite';
 
 // Mock fetch
 const mockFetch = jest.fn();
@@ -30,8 +32,24 @@ describe('CTBC POS API Utils', () => {
     MacKey: '12345678', // 8 character key for DES
   };
 
+  const sslAuthIV = Buffer.alloc(8, 0xab);
+
+  // 組出與 CTBC 相同格式的回應：MERID=...&ApiEnc=<3DES 加密的 Big5 JSON>
+  const buildEncryptedResponse = (payload: Record<string, string>): string => {
+    const big5 = iconv.encode(JSON.stringify(payload), 'big5');
+    const padLength = 8 - (big5.length % 8);
+    const padded = Buffer.concat([big5, Buffer.alloc(padLength, padLength)]);
+    const cipher = crypto.createCipheriv('des-ede3-cbc', Buffer.from(validConfig.MacKey, 'utf8'), sslAuthIV);
+
+    cipher.setAutoPadding(false);
+
+    const encrypted = Buffer.concat([cipher.update(padded), cipher.final()]);
+
+    return `MERID=123456789012345&ApiEnc=${encrypted.toString('hex')}`;
+  };
+
   beforeAll(() => {
-    setSSLAuthIV(Buffer.alloc(8, 0xab));
+    setSSLAuthIV(sslAuthIV);
   });
 
   beforeEach(() => {
@@ -420,6 +438,8 @@ describe('CTBC POS API Utils', () => {
       mockFetch.mockResolvedValueOnce({
         ok: false,
         status: 500,
+        headers: new Headers({ 'content-type': 'text/plain' }),
+        text: jest.fn().mockResolvedValue('Internal Server Error'),
       });
 
       const result = await posApiQuery(validConfig, {
@@ -858,61 +878,134 @@ describe('CTBC POS API Utils', () => {
   });
 
   describe('CTBCHtmlErrorResponseError', () => {
+    // CTBC 系統維護期間實際回傳的公告頁
     const htmlErrorResponse =
-      '<html><head><meta http-equiv,"Content-Type" content,"text/html; charset,UTF-8"><style></style></head>' +
-      '<body lang,ZH-TW style,\'text-justify-trim:punctuation\'><p><b><u>,#37325;,#35201;,#20844;,#21578;</u></b></p>' +
-      '<p>,#30446;,#21069;,#27491;,#36914;,#34892;,#31995;,#32113;,#32173;,#35703;,#20013;,#65292;,#36896;,#25104;,#19981;,#20415;,#65292;,#25964;,#35531;,#35211;,#35538;!</p>' +
-      '<p>,nbsp;</p><p>,#20013;,#22283;,#20449;,#35351; ,#25964;,#21855;</p></body></html>';
+      '<html><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"><style></style></head>' +
+      "<body lang=ZH-TW style='text-justify-trim:punctuation'><p><b><u>&#37325;&#35201;&#20844;&#21578;</u></b></p>" +
+      '<p>&#30446;&#21069;&#27491;&#36914;&#34892;&#31995;&#32113;&#32173;&#35703;&#20013;&#65292;&#36896;&#25104;&#19981;&#20415;&#65292;&#25964;&#35531;&#35211;&#35538;!</p>' +
+      '<p>&nbsp;</p><p>&#20013;&#22283;&#20449;&#35351; &#25964;&#21855;</p></body></html>';
+
+    const queryParams = {
+      MERID: '123456789012345',
+      'LID-M': 'TEST_ORDER_123',
+    };
 
     it('should throw CTBCHtmlErrorResponseError when CTBC returns an HTML error page', async () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,
+        status: 200,
+        headers: new Headers({ 'content-type': 'text/html; charset=UTF-8' }),
         text: jest.fn().mockResolvedValue(htmlErrorResponse),
       });
 
-      await expect(
-        posApiQuery(validConfig, {
-          MERID: '123456789012345',
-          'LID-M': 'TEST_ORDER_123',
-        }),
-      ).rejects.toThrow(CTBCHtmlErrorResponseError);
+      await expect(posApiQuery(validConfig, queryParams)).rejects.toThrow(CTBCHtmlErrorResponseError);
+    });
+
+    it('should detect a DOCTYPE-prefixed HTML page', async () => {
+      const doctypeResponse = `<!DOCTYPE html>\n<html><body>系統維護中</body></html>`;
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        headers: new Headers(),
+        text: jest.fn().mockResolvedValue(doctypeResponse),
+      });
+
+      await expect(posApiQuery(validConfig, queryParams)).rejects.toThrow(CTBCHtmlErrorResponseError);
+    });
+
+    it('should detect an HTML error page served with a non-2xx status code', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 503,
+        headers: new Headers({ 'content-type': 'text/html' }),
+        text: jest.fn().mockResolvedValue(htmlErrorResponse),
+      });
+
+      await expect(posApiQuery(validConfig, queryParams)).rejects.toThrow(CTBCHtmlErrorResponseError);
+    });
+
+    it('should detect an HTML page by content-type even when the body is not recognisable', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        headers: new Headers({ 'content-type': 'text/html; charset=big5' }),
+        text: jest.fn().mockResolvedValue('<!-- maintenance -->\n<body>系統維護中</body>'),
+      });
+
+      await expect(posApiQuery(validConfig, queryParams)).rejects.toThrow(CTBCHtmlErrorResponseError);
     });
 
     it('should carry the raw response text on the responseText property', async () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,
+        status: 200,
+        headers: new Headers({ 'content-type': 'text/html' }),
         text: jest.fn().mockResolvedValue(htmlErrorResponse),
       });
 
       let caughtError: unknown;
 
       try {
-        await posApiQuery(validConfig, {
-          MERID: '123456789012345',
-          'LID-M': 'TEST_ORDER_123',
-        });
+        await posApiQuery(validConfig, queryParams);
       } catch (error) {
         caughtError = error;
       }
 
       expect(caughtError).toBeInstanceOf(CTBCHtmlErrorResponseError);
       expect((caughtError as CTBCHtmlErrorResponseError).responseText).toBe(htmlErrorResponse);
-      expect((caughtError as CTBCHtmlErrorResponseError).message).toContain(htmlErrorResponse);
       expect((caughtError as CTBCHtmlErrorResponseError).name).toBe('CTBCHtmlErrorResponseError');
     });
 
-    it('should not throw for a normal (non-HTML) response', async () => {
+    it('should truncate the embedded page in the error message but keep it whole on responseText', async () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,
+        status: 200,
+        headers: new Headers({ 'content-type': 'text/html' }),
+        text: jest.fn().mockResolvedValue(htmlErrorResponse),
+      });
+
+      let caughtError: unknown;
+
+      try {
+        await posApiQuery(validConfig, queryParams);
+      } catch (error) {
+        caughtError = error;
+      }
+
+      const error = caughtError as CTBCHtmlErrorResponseError;
+
+      expect(htmlErrorResponse.length).toBeGreaterThan(200);
+      expect(error.message).toContain(htmlErrorResponse.slice(0, 200));
+      expect(error.message).not.toContain(htmlErrorResponse);
+      expect(error.message.length).toBeLessThan(htmlErrorResponse.length);
+      expect(error.responseText).toBe(htmlErrorResponse);
+    });
+
+    it('should parse a normal (non-HTML) response instead of throwing', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        headers: new Headers({ 'content-type': 'text/plain' }),
+        text: jest.fn().mockResolvedValue(buildEncryptedResponse({ RespCode: '0', ErrCode: '00', CurrentState: '1' })),
+      });
+
+      const result = await posApiQuery(validConfig, queryParams);
+
+      expect(result).toEqual(expect.objectContaining({ RespCode: '0', ErrCode: '00', CurrentState: '1' }));
+    });
+
+    it('should still return ERR_RESPONSE_PARSE_FAILED for a malformed non-HTML response', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        headers: new Headers({ 'content-type': 'text/plain' }),
         text: jest.fn().mockResolvedValue('short=response'),
       });
 
-      const result = await posApiQuery(validConfig, {
-        MERID: '123456789012345',
-        'LID-M': 'TEST_ORDER_123',
-      });
+      const result = await posApiQuery(validConfig, queryParams);
 
-      expect(typeof result).toBe('number');
+      expect(result).toBe(CTBC_ERROR_CODES.ERR_RESPONSE_PARSE_FAILED);
     });
   });
 

--- a/packages/payments-adapter-ctbc-micro-fast-pay/__tests__/ctbc-pos-api-utils.spec.ts
+++ b/packages/payments-adapter-ctbc-micro-fast-pay/__tests__/ctbc-pos-api-utils.spec.ts
@@ -982,6 +982,33 @@ describe('CTBC POS API Utils', () => {
       expect(result).toEqual(expect.objectContaining({ RespCode: '0', ErrCode: '00', CurrentState: '1' }));
     });
 
+    it('should not hang when a non-2xx response never finishes streaming its body', async () => {
+      jest.useFakeTimers();
+
+      const abortAwareText = (signal: AbortSignal): Promise<string> =>
+        new Promise((_resolve, reject) => {
+          signal.addEventListener('abort', () => reject(new Error('The operation was aborted')));
+        });
+
+      mockFetch.mockImplementationOnce((_url: string, options: RequestInit) =>
+        Promise.resolve({
+          ok: false,
+          status: 503,
+          headers: new Headers({ 'content-type': 'text/plain' }),
+          text: () => abortAwareText(options.signal as AbortSignal),
+        }),
+      );
+
+      const pending = posApiQuery(validConfig, queryParams);
+
+      await Promise.resolve();
+      jest.advanceTimersByTime(30000);
+
+      await expect(pending).resolves.toBe(CTBC_ERROR_CODES.ERR_HOST_CONNECTION_FAILED);
+
+      jest.useRealTimers();
+    });
+
     it('should still return ERR_RESPONSE_PARSE_FAILED for a malformed non-HTML response', async () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,

--- a/packages/payments-adapter-ctbc-micro-fast-pay/__tests__/ctbc-pos-api-utils.spec.ts
+++ b/packages/payments-adapter-ctbc-micro-fast-pay/__tests__/ctbc-pos-api-utils.spec.ts
@@ -36,6 +36,8 @@ describe('CTBC POS API Utils', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    // clearAllMocks 不會清掉未被消費的 mockResolvedValueOnce 佇列，殘留值會汙染後續測試
+    mockFetch.mockReset();
   });
 
   describe('Parameter Validation Functions', () => {

--- a/packages/payments-adapter-ctbc-micro-fast-pay/__tests__/ctbc-pos-api-utils.spec.ts
+++ b/packages/payments-adapter-ctbc-micro-fast-pay/__tests__/ctbc-pos-api-utils.spec.ts
@@ -1004,6 +1004,18 @@ describe('CTBC POS API Utils', () => {
       await expect(posApiQuery(validConfig, queryParams)).rejects.toThrow(CTBCHtmlErrorResponseError);
     });
 
+    it('should not be fooled by an HTML page whose links mimic an envelope', async () => {
+      // <a href="/help?a=1&b=2"> 讓 split 後的第 4 段變成 'b'，是合法 hex 但不是 3DES 密文長度
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        headers: new Headers({ 'content-type': 'text/html; charset=UTF-8' }),
+        text: jest.fn().mockResolvedValue('<html><body><a href="/help?a=1&b=2">status</a></body></html>'),
+      });
+
+      await expect(posApiQuery(validConfig, queryParams)).rejects.toThrow(CTBCHtmlErrorResponseError);
+    });
+
     it('should NOT reject a valid CTBC envelope that is mislabelled as text/html', async () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,

--- a/packages/payments-adapter-ctbc-micro-fast-pay/__tests__/ctbc-pos-api-utils.spec.ts
+++ b/packages/payments-adapter-ctbc-micro-fast-pay/__tests__/ctbc-pos-api-utils.spec.ts
@@ -9,6 +9,7 @@ import {
   posApiCapRev,
   posApiSmartCancelOrRefund,
   getPosNextActionFromInquiry,
+  CTBCHtmlErrorResponseError,
 } from '../src/ctbc-pos-api-utils';
 import { setSSLAuthIV } from '../src/ctbc-crypto-core';
 import { CTBC_ERROR_CODES, CTBCPosApiConfig, CTBCPosApiResponse } from '../src/typings';
@@ -850,6 +851,65 @@ describe('CTBC POS API Utils', () => {
       });
 
       // Since the decryption will fail or produce invalid data, we expect an error
+      expect(typeof result).toBe('number');
+    });
+  });
+
+  describe('CTBCHtmlErrorResponseError', () => {
+    const htmlErrorResponse =
+      '<html><head><meta http-equiv,"Content-Type" content,"text/html; charset,UTF-8"><style></style></head>' +
+      '<body lang,ZH-TW style,\'text-justify-trim:punctuation\'><p><b><u>,#37325;,#35201;,#20844;,#21578;</u></b></p>' +
+      '<p>,#30446;,#21069;,#27491;,#36914;,#34892;,#31995;,#32113;,#32173;,#35703;,#20013;,#65292;,#36896;,#25104;,#19981;,#20415;,#65292;,#25964;,#35531;,#35211;,#35538;!</p>' +
+      '<p>,nbsp;</p><p>,#20013;,#22283;,#20449;,#35351; ,#25964;,#21855;</p></body></html>';
+
+    it('should throw CTBCHtmlErrorResponseError when CTBC returns an HTML error page', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: jest.fn().mockResolvedValue(htmlErrorResponse),
+      });
+
+      await expect(
+        posApiQuery(validConfig, {
+          MERID: '123456789012345',
+          'LID-M': 'TEST_ORDER_123',
+        }),
+      ).rejects.toThrow(CTBCHtmlErrorResponseError);
+    });
+
+    it('should carry the raw response text on the responseText property', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: jest.fn().mockResolvedValue(htmlErrorResponse),
+      });
+
+      let caughtError: unknown;
+
+      try {
+        await posApiQuery(validConfig, {
+          MERID: '123456789012345',
+          'LID-M': 'TEST_ORDER_123',
+        });
+      } catch (error) {
+        caughtError = error;
+      }
+
+      expect(caughtError).toBeInstanceOf(CTBCHtmlErrorResponseError);
+      expect((caughtError as CTBCHtmlErrorResponseError).responseText).toBe(htmlErrorResponse);
+      expect((caughtError as CTBCHtmlErrorResponseError).message).toContain(htmlErrorResponse);
+      expect((caughtError as CTBCHtmlErrorResponseError).name).toBe('CTBCHtmlErrorResponseError');
+    });
+
+    it('should not throw for a normal (non-HTML) response', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: jest.fn().mockResolvedValue('short=response'),
+      });
+
+      const result = await posApiQuery(validConfig, {
+        MERID: '123456789012345',
+        'LID-M': 'TEST_ORDER_123',
+      });
+
       expect(typeof result).toBe('number');
     });
   });

--- a/packages/payments-adapter-ctbc-micro-fast-pay/__tests__/ctbc-pos-api-utils.spec.ts
+++ b/packages/payments-adapter-ctbc-micro-fast-pay/__tests__/ctbc-pos-api-utils.spec.ts
@@ -982,6 +982,41 @@ describe('CTBC POS API Utils', () => {
       expect(result).toEqual(expect.objectContaining({ RespCode: '0', ErrCode: '00', CurrentState: '1' }));
     });
 
+    it('should detect an HTML page hidden behind a proxy comment or XML declaration', async () => {
+      const wrapped = '<!-- proxy banner --><html><body><a href="/?x=1&y=2">blocked</a></body></html>';
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        headers: new Headers({ 'content-type': 'text/plain' }),
+        text: jest.fn().mockResolvedValue(wrapped),
+      });
+
+      await expect(posApiQuery(validConfig, queryParams)).rejects.toThrow(CTBCHtmlErrorResponseError);
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        headers: new Headers({ 'content-type': 'text/plain' }),
+        text: jest.fn().mockResolvedValue('<?xml version="1.0"?><html><body>maintenance</body></html>'),
+      });
+
+      await expect(posApiQuery(validConfig, queryParams)).rejects.toThrow(CTBCHtmlErrorResponseError);
+    });
+
+    it('should NOT reject a valid CTBC envelope that is mislabelled as text/html', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        headers: new Headers({ 'content-type': 'text/html; charset=UTF-8' }),
+        text: jest.fn().mockResolvedValue(buildEncryptedResponse({ RespCode: '0', ErrCode: '00', CurrentState: '1' })),
+      });
+
+      const result = await posApiQuery(validConfig, queryParams);
+
+      expect(result).toEqual(expect.objectContaining({ RespCode: '0', ErrCode: '00' }));
+    });
+
     it('should not hang when a non-2xx response never finishes streaming its body', async () => {
       jest.useFakeTimers();
 

--- a/packages/payments-adapter-ctbc-micro-fast-pay/__tests__/ctbc-pos-api-utils.spec.ts
+++ b/packages/payments-adapter-ctbc-micro-fast-pay/__tests__/ctbc-pos-api-utils.spec.ts
@@ -407,19 +407,6 @@ describe('CTBC POS API Utils', () => {
     });
   });
 
-  describe('posApiSmartCancelOrRefund - Error Cases', () => {
-    it('should throw error when transaction is pending', async () => {
-      // Mock a successful query that returns pending state
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        text: jest.fn().mockResolvedValue('MERID=123&ApiEnc=encrypted_data_here'),
-      });
-
-      // We can't easily test this without more complex mocking of the encryption
-      // Skip for now as the validation tests cover the main paths
-    });
-  });
-
   describe('API Error Handling', () => {
     it('should return error code when fetch fails', async () => {
       mockFetch.mockRejectedValueOnce(new Error('Network error'));

--- a/packages/payments-adapter-ctbc-micro-fast-pay/src/ctbc-order.ts
+++ b/packages/payments-adapter-ctbc-micro-fast-pay/src/ctbc-order.ts
@@ -12,6 +12,7 @@ import {
 import { CTBCPayment, debugPayment } from './ctbc-payment';
 import { posApiCancelRefund, posApiSmartCancelOrRefund } from './ctbc-pos-api-utils';
 import { amexCancelRefund, amexSmartCancelOrRefund } from './ctbc-amex-api-utils';
+import { CTBC_HTML_ERROR_RESPONSE_FAILED_CODE, CTBCHtmlErrorResponseError } from './errors';
 import type { CTBCAmexCancelRefundParams, CTBCAmexConfig, CTBCAmexRefundParams } from './typings';
 import {
   CTBCCheckoutWithBoundCardRequestPayload,
@@ -357,7 +358,10 @@ export class CTBCOrder<OCM extends CTBCOrderCommitMessage = CTBCOrderCommitMessa
         if (this._state !== OrderState.FAILED) {
           this._state = OrderState.FAILED;
 
-          if (error instanceof Error) {
+          if (error instanceof CTBCHtmlErrorResponseError) {
+            this._failedCode = CTBC_HTML_ERROR_RESPONSE_FAILED_CODE;
+            this._failedMessage = error.message;
+          } else if (error instanceof Error) {
             this._failedMessage = error.message;
           } else {
             this._failedMessage = 'Unknown refund error';
@@ -522,7 +526,10 @@ export class CTBCOrder<OCM extends CTBCOrderCommitMessage = CTBCOrderCommitMessa
         if (this._state !== OrderState.FAILED) {
           this._state = OrderState.FAILED;
 
-          if (error instanceof Error) {
+          if (error instanceof CTBCHtmlErrorResponseError) {
+            this._failedCode = CTBC_HTML_ERROR_RESPONSE_FAILED_CODE;
+            this._failedMessage = error.message;
+          } else if (error instanceof Error) {
             this._failedMessage = error.message;
           } else {
             this._failedMessage = 'Unknown cancel refund error';

--- a/packages/payments-adapter-ctbc-micro-fast-pay/src/ctbc-payment.ts
+++ b/packages/payments-adapter-ctbc-micro-fast-pay/src/ctbc-payment.ts
@@ -33,7 +33,7 @@ import {
 } from './ctbc-crypto-core';
 import { CTBCOrder } from './ctbc-order';
 import { posApiQuery } from './ctbc-pos-api-utils';
-import { CtbcPaymentFailedError } from './errors';
+import { CtbcPaymentFailedError, CTBCPosQueryFailedError } from './errors';
 import {
   BindCardRequestCache,
   CTBCAmexConfig,
@@ -750,9 +750,7 @@ export class CTBCPayment<CM extends CTBCOrderCommitMessage = CTBCOrderCommitMess
           `Query failed for order ${id}, RespCode: ${result.RespCode} - ErrCode: ${result.ErrCode} - ErrDesc: ${result.ERRDESC || 'Unknown error'}`,
         );
 
-        throw new Error(
-          `Query failed, RespCode: ${result.RespCode} - ErrCode: ${result.ErrCode} - ErrDesc: ${result.ERRDESC || 'Unknown error'}`,
-        );
+        throw new CTBCPosQueryFailedError(result.RespCode, result.ErrCode, result.ERRDESC);
       }
 
       debugPayment(`Query successful for order ${id}: ${JSON.stringify(result)}`);

--- a/packages/payments-adapter-ctbc-micro-fast-pay/src/ctbc-pos-api-utils.ts
+++ b/packages/payments-adapter-ctbc-micro-fast-pay/src/ctbc-pos-api-utils.ts
@@ -200,13 +200,40 @@ function pkcs5Unpad(data: Buffer): Buffer {
   return result;
 }
 
-// CTBC 系統維護時會回傳 HTML 公告頁，可能帶 <!DOCTYPE>、BOM，也可能搭配 5xx 狀態碼
+// 合法回應為 key1=value1&key2=value2&<hex>，第 4 段必為十六進位密文。
+// 先確認是合法封包再判 HTML，避免 CTBC 對正常回應誤標 text/html 時整條金流被擋下。
+function looksLikeCtbcEnvelope(responseText: string): boolean {
+  const parts = responseText.trim().split(/[&=]/);
+
+  return parts.length >= 4 && /^[0-9a-f]+$/i.test(parts[3]);
+}
+
+// 維護公告頁前面可能夾 BOM、XML 宣告或 proxy/WAF 注入的註解，需逐層剝除後再比對
+function stripLeadingNoise(responseText: string): string {
+  let rest = responseText.replace(/^[\s\uFEFF]+/, '');
+
+  for (;;) {
+    const next = rest.replace(/^<\?xml[^>]*\?>\s*/i, '').replace(/^<!--[\s\S]*?-->\s*/, '');
+
+    if (next === rest) {
+      return rest;
+    }
+
+    rest = next;
+  }
+}
+
+// CTBC 系統維護時會回傳 HTML 公告頁，可能帶 <!DOCTYPE>，也可能搭配 5xx 狀態碼
 function isHtmlErrorResponse(contentType: string | null, responseText: string): boolean {
-  if (contentType && /text\/html/i.test(contentType)) {
+  if (looksLikeCtbcEnvelope(responseText)) {
+    return false;
+  }
+
+  if (contentType && /^\s*(?:text\/html|application\/xhtml\+xml)\s*(?:;|$)/i.test(contentType)) {
     return true;
   }
 
-  return /^[\s\uFEFF]*(?:<!doctype\s+html|<html)/i.test(responseText);
+  return /^(?:<!doctype\s+html|<html|<head|<body)/i.test(stripLeadingNoise(responseText));
 }
 
 function parseResponse(responseStr: string, macKey: string): CTBCPosApiResponse | number {

--- a/packages/payments-adapter-ctbc-micro-fast-pay/src/ctbc-pos-api-utils.ts
+++ b/packages/payments-adapter-ctbc-micro-fast-pay/src/ctbc-pos-api-utils.ts
@@ -200,12 +200,20 @@ function pkcs5Unpad(data: Buffer): Buffer {
   return result;
 }
 
-// 合法回應為 key1=value1&key2=value2&<hex>，第 4 段必為十六進位密文。
+// 合法回應為 key1=value1&key2=value2&<hex>，第 4 段必為 3DES 密文，
+// 因此長度必為 8-byte 區塊的倍數（16 個十六進位字元）。單純檢查「是否為 hex」不夠：
+// HTML 頁面裡一個 <a href="?a=1&b=2"> 就會讓第 4 段變成 'b'，剛好通過而繞開偵測。
 // 先確認是合法封包再判 HTML，避免 CTBC 對正常回應誤標 text/html 時整條金流被擋下。
 function looksLikeCtbcEnvelope(responseText: string): boolean {
   const parts = responseText.trim().split(/[&=]/);
 
-  return parts.length >= 4 && /^[0-9a-f]+$/i.test(parts[3]);
+  if (parts.length < 4) {
+    return false;
+  }
+
+  const ciphertext = parts[3];
+
+  return ciphertext.length >= 16 && ciphertext.length % 16 === 0 && /^[0-9a-f]+$/i.test(ciphertext);
 }
 
 // 維護公告頁前面可能夾 BOM、XML 宣告或 proxy/WAF 注入的註解，需逐層剝除後再比對

--- a/packages/payments-adapter-ctbc-micro-fast-pay/src/ctbc-pos-api-utils.ts
+++ b/packages/payments-adapter-ctbc-micro-fast-pay/src/ctbc-pos-api-utils.ts
@@ -12,6 +12,7 @@ import {
   CTBCPosApiCapRevParams,
 } from './typings';
 import { debugPayment } from './ctbc-payment';
+import { CTBCHtmlErrorResponseError } from './errors';
 
 function checkMerid(input: string): true | number {
   if (!input) {
@@ -199,19 +200,13 @@ function pkcs5Unpad(data: Buffer): Buffer {
   return result;
 }
 
-export class CTBCHtmlErrorResponseError extends Error {
-  readonly responseText: string;
-
-  constructor(responseText: string) {
-    super(`CTBC API returned an HTML error page: ${responseText}`);
-
-    this.name = 'CTBCHtmlErrorResponseError';
-    this.responseText = responseText;
+// CTBC 系統維護時會回傳 HTML 公告頁，可能帶 <!DOCTYPE>、BOM，也可能搭配 5xx 狀態碼
+function isHtmlErrorResponse(contentType: string | null, responseText: string): boolean {
+  if (contentType && /text\/html/i.test(contentType)) {
+    return true;
   }
-}
 
-function isHtmlErrorResponse(responseText: string): boolean {
-  return /^\s*<html/i.test(responseText);
+  return /^[\s\uFEFF]*(?:<!doctype\s+html|<html)/i.test(responseText);
 }
 
 function parseResponse(responseStr: string, macKey: string): CTBCPosApiResponse | number {
@@ -244,6 +239,7 @@ function parseResponse(responseStr: string, macKey: string): CTBCPosApiResponse 
 }
 
 // 網路請求發送與回應處理
+// @throws {CTBCHtmlErrorResponseError} CTBC 回傳 HTML 錯誤／維護公告頁時拋出；其餘錯誤一律以錯誤碼回傳
 async function sendAndGetResponse(
   config: CTBCPosApiConfig,
   merid: string,
@@ -278,17 +274,18 @@ async function sendAndGetResponse(
 
     clearTimeout(timeoutId);
 
-    if (!response.ok) {
-      return CTBC_ERROR_CODES.ERR_HOST_CONNECTION_FAILED;
-    }
-
     const responseText = await response.text();
 
     debugPayment('CTBC API 回應狀態:', response.status);
     debugPayment('CTBC API 回應內容:', responseText);
 
-    if (isHtmlErrorResponse(responseText)) {
+    // 維護公告頁常伴隨 5xx 狀態碼，需先於 response.ok 判斷，否則會被誤判為連線失敗
+    if (isHtmlErrorResponse(response.headers?.get('content-type') ?? null, responseText)) {
       throw new CTBCHtmlErrorResponseError(responseText);
+    }
+
+    if (!response.ok) {
+      return CTBC_ERROR_CODES.ERR_HOST_CONNECTION_FAILED;
     }
 
     return parseResponse(responseText, config.MacKey);
@@ -304,6 +301,7 @@ async function sendAndGetResponse(
 }
 
 // POS API 查詢功能
+// @throws {CTBCHtmlErrorResponseError} CTBC 回傳 HTML 錯誤／維護公告頁時拋出；其餘錯誤以錯誤碼回傳
 export async function posApiQuery(
   config: CTBCPosApiConfig,
   params: CTBCPosApiQueryParams,
@@ -368,6 +366,7 @@ export async function posApiQuery(
 }
 
 // POS API 退款功能
+// @throws {CTBCHtmlErrorResponseError} CTBC 回傳 HTML 錯誤／維護公告頁時拋出；其餘錯誤以錯誤碼回傳
 export async function posApiRefund(
   config: CTBCPosApiConfig,
   params: CTBCPosApiRefundParams,
@@ -454,6 +453,7 @@ export async function posApiRefund(
 }
 
 // POS API 退款撤銷功能
+// @throws {CTBCHtmlErrorResponseError} CTBC 回傳 HTML 錯誤／維護公告頁時拋出；其餘錯誤以錯誤碼回傳
 export async function posApiCancelRefund(
   config: CTBCPosApiConfig,
   params: CTBCPosApiCancelRefundParams,
@@ -540,6 +540,7 @@ export async function posApiCancelRefund(
 }
 
 // POS API 授權取消 (Reversal)
+// @throws {CTBCHtmlErrorResponseError} CTBC 回傳 HTML 錯誤／維護公告頁時拋出；其餘錯誤以錯誤碼回傳
 export async function posApiReversal(
   config: CTBCPosApiConfig,
   params: CTBCPosApiReversalParams,
@@ -585,6 +586,7 @@ export async function posApiReversal(
 }
 
 // POS API 請款取消 (CapRev)
+// @throws {CTBCHtmlErrorResponseError} CTBC 回傳 HTML 錯誤／維護公告頁時拋出；其餘錯誤以錯誤碼回傳
 export async function posApiCapRev(
   config: CTBCPosApiConfig,
   params: CTBCPosApiCapRevParams,
@@ -683,6 +685,7 @@ export function getPosNextActionFromInquiry(inquiry: CTBCPosApiResponse): PosAct
 export type PosAction = 'Reversal' | 'CapRev' | 'Refund' | 'None' | 'Pending' | 'Failed' | 'Forbidden';
 
 // 智慧取消/退款（POS 版）：查詢 → 決策 → 執行
+// @throws {CTBCHtmlErrorResponseError} CTBC 回傳 HTML 錯誤／維護公告頁時拋出；其餘錯誤以錯誤碼回傳
 export async function posApiSmartCancelOrRefund(
   config: CTBCPosApiConfig,
   params: CTBCPosApiRefundParams,

--- a/packages/payments-adapter-ctbc-micro-fast-pay/src/ctbc-pos-api-utils.ts
+++ b/packages/payments-adapter-ctbc-micro-fast-pay/src/ctbc-pos-api-utils.ts
@@ -245,6 +245,9 @@ async function sendAndGetResponse(
   merid: string,
   requestData: string,
 ): Promise<CTBCPosApiResponse | number> {
+  const controller = new AbortController();
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
   try {
     const macSubString = getMacValueSub(requestData, config.MacKey);
     const apiEncString = getMacValue(requestData + macSubString, config.MacKey);
@@ -254,8 +257,7 @@ async function sendAndGetResponse(
       MERID: merid,
     });
 
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), 30000);
+    timeoutId = setTimeout(() => controller.abort(), 30000);
 
     debugPayment('CTBC API 請求 URL:', config.URL);
     debugPayment('CTBC API 請求資料:', requestData);
@@ -272,8 +274,7 @@ async function sendAndGetResponse(
 
     const response = await fetch(config.URL, fetchOptions);
 
-    clearTimeout(timeoutId);
-
+    // 逾時必須涵蓋 body 讀取：維護頁可能只回 header 就把 body 掛住
     const responseText = await response.text();
 
     debugPayment('CTBC API 回應狀態:', response.status);
@@ -297,6 +298,8 @@ async function sendAndGetResponse(
     debugPayment('CTBC API request failed:', error);
 
     return CTBC_ERROR_CODES.ERR_HOST_CONNECTION_FAILED;
+  } finally {
+    clearTimeout(timeoutId);
   }
 }
 

--- a/packages/payments-adapter-ctbc-micro-fast-pay/src/ctbc-pos-api-utils.ts
+++ b/packages/payments-adapter-ctbc-micro-fast-pay/src/ctbc-pos-api-utils.ts
@@ -199,6 +199,21 @@ function pkcs5Unpad(data: Buffer): Buffer {
   return result;
 }
 
+export class CTBCHtmlErrorResponseError extends Error {
+  readonly responseText: string;
+
+  constructor(responseText: string) {
+    super(`CTBC API returned an HTML error page: ${responseText}`);
+
+    this.name = 'CTBCHtmlErrorResponseError';
+    this.responseText = responseText;
+  }
+}
+
+function isHtmlErrorResponse(responseText: string): boolean {
+  return /^\s*<html/i.test(responseText);
+}
+
 function parseResponse(responseStr: string, macKey: string): CTBCPosApiResponse | number {
   // 解析格式：key1=value1&key2=value2&encryptedData
   const parts = responseStr.split(/[&=]/);
@@ -272,8 +287,16 @@ async function sendAndGetResponse(
     debugPayment('CTBC API 回應狀態:', response.status);
     debugPayment('CTBC API 回應內容:', responseText);
 
+    if (isHtmlErrorResponse(responseText)) {
+      throw new CTBCHtmlErrorResponseError(responseText);
+    }
+
     return parseResponse(responseText, config.MacKey);
   } catch (error) {
+    if (error instanceof CTBCHtmlErrorResponseError) {
+      throw error;
+    }
+
     debugPayment('CTBC API request failed:', error);
 
     return CTBC_ERROR_CODES.ERR_HOST_CONNECTION_FAILED;

--- a/packages/payments-adapter-ctbc-micro-fast-pay/src/errors.ts
+++ b/packages/payments-adapter-ctbc-micro-fast-pay/src/errors.ts
@@ -11,6 +11,9 @@ export class CtbcPaymentFailedError extends Error {
 // 錯誤訊息中僅保留開頭片段，完整內容請取用 responseText，避免維護公告頁灌爆 log
 const HTML_ERROR_PREVIEW_LENGTH = 200;
 
+// CTBC 回傳 HTML 錯誤頁時，訂單上記錄的失敗代碼（POS 錯誤碼為數字，故以字串常數區隔）
+export const CTBC_HTML_ERROR_RESPONSE_FAILED_CODE = 'HTML_ERROR_RESPONSE';
+
 export class CTBCHtmlErrorResponseError extends Error {
   readonly responseText: string;
 

--- a/packages/payments-adapter-ctbc-micro-fast-pay/src/errors.ts
+++ b/packages/payments-adapter-ctbc-micro-fast-pay/src/errors.ts
@@ -8,6 +8,25 @@ export class CtbcPaymentFailedError extends Error {
   }
 }
 
+// 錯誤訊息中僅保留開頭片段，完整內容請取用 responseText，避免維護公告頁灌爆 log
+const HTML_ERROR_PREVIEW_LENGTH = 200;
+
+export class CTBCHtmlErrorResponseError extends Error {
+  readonly responseText: string;
+
+  constructor(responseText: string) {
+    const preview =
+      responseText.length > HTML_ERROR_PREVIEW_LENGTH
+        ? `${responseText.slice(0, HTML_ERROR_PREVIEW_LENGTH)}…`
+        : responseText;
+
+    super(`CTBC API returned an HTML error page: ${preview}`);
+
+    this.name = 'CTBCHtmlErrorResponseError';
+    this.responseText = responseText;
+  }
+}
+
 export class CTBCPosQueryFailedError extends Error {
   readonly respCode?: string;
   readonly errCode?: string;

--- a/packages/payments-adapter-ctbc-micro-fast-pay/src/errors.ts
+++ b/packages/payments-adapter-ctbc-micro-fast-pay/src/errors.ts
@@ -7,3 +7,20 @@ export class CtbcPaymentFailedError extends Error {
     this.orderId = orderId;
   }
 }
+
+export class CTBCPosQueryFailedError extends Error {
+  readonly respCode?: string;
+  readonly errCode?: string;
+  readonly errDesc: string;
+
+  constructor(respCode: string | undefined, errCode: string | undefined, errDesc: string | undefined) {
+    const resolvedErrDesc = errDesc || 'Unknown error';
+
+    super(`Query failed, RespCode: ${respCode} - ErrCode: ${errCode} - ErrDesc: ${resolvedErrDesc}`);
+
+    this.name = 'CTBCPosQueryFailedError';
+    this.respCode = respCode;
+    this.errCode = errCode;
+    this.errDesc = resolvedErrDesc;
+  }
+}

--- a/packages/payments-adapter-ctbc-micro-fast-pay/src/index.ts
+++ b/packages/payments-adapter-ctbc-micro-fast-pay/src/index.ts
@@ -35,6 +35,7 @@ export {
   posApiCapRev,
   posApiSmartCancelOrRefund,
   getPosNextActionFromInquiry,
+  CTBCHtmlErrorResponseError,
 } from './ctbc-pos-api-utils';
 
 // AMEX SOAP 工具函數（回傳與 POS 統一的 CTBCPosApiResponse）

--- a/packages/payments-adapter-ctbc-micro-fast-pay/src/index.ts
+++ b/packages/payments-adapter-ctbc-micro-fast-pay/src/index.ts
@@ -1,5 +1,5 @@
 /* istanbul ignore file: re-export barrel file */
-export { CTBCBindCardRequestState, CTBCOrderState } from './typings';
+export { CTBCBindCardRequestState, CTBCOrderState, CTBC_ERROR_CODES } from './typings';
 
 export type {
   CTBCBindCardRequestPayload,
@@ -12,7 +12,6 @@ export type {
   CTBCPosApiRefundParams,
   CTBCPosApiCancelRefundParams,
   CTBCPosApiResponse,
-  CTBC_ERROR_CODES,
   CTBCAmexConfig,
   CTBCAmexInquiryParams,
   CTBCAmexRefundParams,

--- a/packages/payments-adapter-ctbc-micro-fast-pay/src/index.ts
+++ b/packages/payments-adapter-ctbc-micro-fast-pay/src/index.ts
@@ -35,7 +35,6 @@ export {
   posApiCapRev,
   posApiSmartCancelOrRefund,
   getPosNextActionFromInquiry,
-  CTBCHtmlErrorResponseError,
 } from './ctbc-pos-api-utils';
 
 // AMEX SOAP 工具函數（回傳與 POS 統一的 CTBCPosApiResponse）


### PR DESCRIPTION
- Add CTBCHtmlErrorResponseError to signal when CTBC returns an HTML error page instead of the expected encoded response, so callers can distinguish maintenance/outage pages from normal parsing failures
- Throw this error from sendAndGetResponse and re-throw it past the generic catch block instead of masking it as ERR_HOST_CONNECTION_FAILED
- Expose responseText on the error for logging/alerting on the raw payload, and export the class from the package entrypoint
- Cover the new behavior with tests for detection, message/property content, and the non-HTML passthrough case